### PR TITLE
Changes to Spell Slots

### DIFF
--- a/dmsguide.md
+++ b/dmsguide.md
@@ -15,7 +15,6 @@ Both arrows and bolts can be enchanted. When using magic ammunition add a wound 
 A weapon whose blade can ignite in flames. Can be used as a torch. Grants the _Flame Slash_ maneuver.
 
 ##### Flame Slash
-___
 - **AP Cost:** 5
 - **Weapon:** Slashing
 - **Range:** Melee
@@ -29,7 +28,6 @@ A shield covered in eyes that dart around, looking for any threats. Gives 1 supe
 
 
 ##### Terrifying Gaze
-___
 - **AP Cost:** 5
 - **Weapon:** Shield
 - **Range:** Area of Control
@@ -59,7 +57,6 @@ A strange ring that wards the wearer from danger. When making a defense roll, yo
 A blade that emits a cutting force beyond the edge of its sword. Damage dealt with this weapon is considered Force damage. You gain the _Cutting Force_ manuever.
 
 ##### Cutting Force
-___
 - **AP Cost:** 6
 - **Weapon:** Slashing
 - **Range:** 7
@@ -73,7 +70,6 @@ Send a blast of force at a target within range. Make a normal weapon attack agai
 A hammer infused with the power of earth. When attacking Elementals you deal an additional wound die in damage. You also gain the _Quake_ manuever.
 
 ##### Quake
-___
 - **AP Cost:** 7
 - **Weapon:** Bludgeoning
 - **Range:** Melee
@@ -86,7 +82,6 @@ Smash your hammer into the ground, causing the earth in your zone of control to 
 A hatchet inscribed with runes, cold to the touch. When thrown the Hatchet appears back in your hand at the end of your turn. You gain the _Icy Impact_ manuever.
 
 ##### Icy Impact
-___
 - **AP Cost:** 6
 - **Weapon:** Slashing
 - **Range:** Thrown
@@ -252,7 +247,6 @@ While wearing this mask you add 1 proficiency die to all spellcasting rolls. Whe
 ***Curse.*** This item is cursed. After attuning to the mask you are unable to part with it, wearing it covering your face or off to one side. If you reach 0 wounds or suffer an effect that would kill you outright, the Mask consumes you and you return as a Shadowbeast. You are stalked by a powerful entity of shadow that wants the mask. This entity knows your general location and you cannot hide from it through magic.
 
 ##### Shadow Magic
-___
 - **AP Cost:** 7
 - **Damage:** Death
 - **Range:** 7
@@ -260,7 +254,6 @@ ___
 You summon 3 shadowbolts and launch them at targets in range. You may choose different targets, or have all bolts hit the same target. Make a curse spellcasting roll against the targets defense for each bolt, dealing 2 wound die on hit, and giving Hex 1 on crit. You gain 1 temporary wound for every 3 wounds dealt by this attack.
 
 ##### Orb of Destruction
-___
 - **AP Cost:** 9
 - **Damage:** Death
 - **Range:** 10
@@ -333,7 +326,6 @@ This black metal band resizes itself to fit around the wearers forearm. Once per
 This dull blue dagger emits faint wisps of smoke visible even when sheathed. You gain the Shadowwalk maneuver while holding this dagger.
 
 ##### Shadowwalk
-___
 - **AP Cost:** 5
 - **Damage:** Death
 - **Range:** 5/10
@@ -395,3 +387,25 @@ ___
 - **Roll:** 2 Bad dice, 1 Terrible die
 
 Your max wounds increases by 1 for the next 24 hours. Every time you roll a healing surge you heal an extra wound.
+
+
+#### Heart of the Forest
+*Wondrous Item, Requires Attunement*
+
+While wearing this pendant you gain 1 Stamina and have expertise when making Poison saves.
+
+#### Circlet of Power +1, +2, +3
+*Wondrous Item, Requires Attunement*
+
+A circlet worn around your wrist, adorned in arcane runes. When making a spellcasting roll you may reroll a number of dice equal to the circlets modifier.
+
+#### Spriggan Tunic
+*Magic Padded Armor*
+
+A tunic woven from the hair of a spriggan. While outside you have expertise in stealth as long as you aren't moving. While in a forest you gain the _Treewalk_ Maneuver
+
+##### Treewalk
+- **AP Cost:** 5
+- **Range:** 7
+
+When standing next to a tree you may magically enter the tree. While inside the tree you are untargetable by effects that do not target the ethereal plane. At the start of your next turn you appear beside a tree within range.

--- a/monstermanual.md
+++ b/monstermanual.md
@@ -592,7 +592,7 @@ ___
 ___
 ***Enchanting Presence.*** Any attack, maneuver or spell attack against this target adds 2 Terrible dice to their rolls.
 
-***Innate Magic.*** This creature does not require a codex to cast spells. Regardless of spell type they roll 2/2/1/0/0 for all spells, and add 2 Superior dice when the target of _Counter Spell_. The have 3 3rd level spell slots and know the following spells: _Phantasmal Blades_, _Fireball_, _, _Beacon_, _Sword Burst_, _Healing Word_.
+***Innate Magic.*** This creature does not require a codex to cast spells. Regardless of spell type they roll 2/2/1/0/0 for all spells, and add 2 Superior dice when the target of _Counter Spell_. The are a 3rd level caster with 11 mana and know the following spells: _Phantasmal Blades_, _Fireball_, _, _Beacon_, _Sword Burst_, _Healing Word_.
 
 **Actions**
 
@@ -661,7 +661,7 @@ ___
 ___
 ***Quick.*** This creature is immune to opportunity attacks when using the Move action (but not sprint).
 
-***Spellcaster.*** This creature is an Arcane (2) caster and has 3 1st and 1 2nd level spell slots. They have a codex with the following spells: _Firebolt, Cold Snap, Static Shock, Poison Trap_.
+***Spellcaster.*** This creature is proficient Arcane (2) spells. They are a 2nd level caster with 5 mana and have a codex with the following spells: _Firebolt, Cold Snap, Static Shock, Poison Trap_.
 
 **Actions**
 
@@ -738,7 +738,7 @@ ___
 ___
 ***Enduring.*** When taking lethal damage, as long as the attack dealt 3 or fewer wounds the Orc survives with 1 wound. Can only be used once per day.
 
-***Spellcaster.*** The Orc Shaman is proficient in Curse (3) and Divine (1) spells. They have 3 1st, 2 2nd and 3rd, and 1 4th level spell slot and a codex with the following spells: _Hex, Quicken, Web, Frog Morph, Healing Word, Regeneration_.
+***Spellcaster.*** The Orc Shaman is proficient in Curse (3) and Divine (1) spells. They are a 4th level caster with 10 mana and a codex with the following spells: _Hex, Quicken, Web, Frog Morph, Healing Word, Regeneration_.
 
 **Actions**
 
@@ -798,7 +798,7 @@ ___
 |-1/0|0/0|1/0|3/1|1/1|1/0|
 
 ___
-***Spellcaster.*** This creature is an Arcane (2) caster. They have 3 1st level and 1 2nd level spell slot, and a codex with the following spells prepared: _Firebolt, Static Shock, Arcane Blasts, Call Lightning, Combust, Misty Step._
+***Spellcaster.*** This creature is proficient with Arcane (2) spells. They are a 2nd level caster with 6 mana and a codex with the following spells prepared: _Firebolt, Static Shock, Arcane Blasts, Call Lightning, Combust, Misty Step._
 
 **Actions**
 
@@ -817,7 +817,7 @@ ___
 |-1/0|3/0|0/0|2/1|1/1|0/0|
 
 ___
-***Spellcaster.*** This creature is an Arcane (1) caster. They have 3 1st level and 1 2nd level spell slot, and a codex with the following spells prepared: _Cold Snap, Chilling Ray, Ray of Sickness, Detect Magic, Misty Step._
+***Spellcaster.*** This creature is proficient with Arcane (1) spells. They are a 2nd level caster with 5 mana and a codex with the following spells prepared: _Cold Snap, Chilling Ray, Ray of Sickness, Detect Magic, Misty Step._
 
 ***Infiltrator.*** Has Expertise in Stealth and Perception.
 
@@ -838,7 +838,7 @@ ___
 |-1/0|0/0|1/0|3/1|2/1|1/0|
 
 ___
-***Spellcaster.*** This creature is an Arcane (3) caster. They have 3 1st level and 2 2nd and 3rd level spell slots, and a codex with the following spells prepared: _Firebolt, Static Shock, Arcane Blasts, Call Lightning, Misty Step, Fireball, Phantasmal Blades._
+***Spellcaster.*** This creature is proficient with Arcane (3) spells. They are a 3rd level caster with 9 mana and a codex with the following spells prepared: _Firebolt, Static Shock, Arcane Blasts, Call Lightning, Misty Step, Fireball, Phantasmal Blades._
 
 **Actions**
 

--- a/roll20/farhome.html
+++ b/roll20/farhome.html
@@ -50,7 +50,7 @@
             name="attr_chasave" value="0" />
         <button type='roll' name='roll_save' value='!rtmp `name|Charisma Save` `roll1|save cha`'></button>
         <br />
-        <span class="simple120">Action Points</span><input type="number" name="attr_actionpoints" value="0" />/<input
+        <span class="simple120">AP</span><input type="number" name="attr_actionpoints" value="0" />/<input
             type="number" name="attr_maxactionpoints" value="0" />
         <br />
         <span class="simple120">Move/Sprint</span><input type="number" name="attr_movespeed" value="0" />/<input
@@ -103,20 +103,15 @@
         <br />
         <input class="sheet-skillsCur sheet-hidden" type="checkbox" name="attr_curvis" value="1">
         <div class="sheet-skillsec-cur">
-            <div class="2colrow">
-                <div class="col">
-                    <label style="width:25px">CP</label><input style="width:3em;max-width: 3em;" type="number"
-                        name="attr_cp" value="0" />
-                    <label style="width:25px">GP</label><input style="width:3em;max-width: 3em;" type="number"
-                        name="attr_gp" value="0" />
-                </div>
-                <div class="col">
-                    <label style="width:25px">SP</label><input style="width:3em;max-width: 3em;" type="number"
-                        name="attr_sp" value="0" />
-                    <label style="width:25px">PP</label><input style="width:3em;max-width: 3em;" type="number"
-                        name="attr_pp" value="0" />
-                </div>
-            </div>
+            <label class="short">Trites</label><input style="width:3em;max-width: 3em;" type="number"
+                name="attr_ct" value="0" />
+                <br />
+            <label class="short">Crosses</label><input style="width:3em;max-width: 3em;" type="number"
+                name="attr_sc" value="0" />
+                <br />
+            <label class="short">Talents</label><input style="width:3em;max-width: 3em;" type="number"
+                name="attr_pt" value="0" />
+                <br />
         </div>
     </div>
     <div class="skills">
@@ -471,48 +466,13 @@
         </div>
     </div>
     <div class="spells">
-        <h3>Spell Slots</h3>
+        <h3>Spellcasting</h3>
         <br />
-        <div class="inlinespell">
-            <div style="margin-left: 15px" class="simple120">1st</div>
-            <br />
-            <input type="number" name="attr_first" value="0" />/<input type="number" name="attr_firstmax" value="0" />
-            <br />
-            <div style="margin-left: 15px" class="simple120">2nd</div>
-            <br />
-            <input type="number" name="attr_second" value="0" />/<input type="number" name="attr_secondmax" value="0" />
-            <br />
-            <div style="margin-left: 15px" class="simple120">3rd</div>
-            <br />
-            <input type="number" name="attr_third" value="0" />/<input type="number" name="attr_thirdmax" value="0" />
-        </div>
-        <div style="margin:-3px" class="inlinespell">
-            <div style="margin-left: 15px" class="simple120">4th</div>
-            <br />
-            <input type="number" name="attr_fourth" value="0" />/<input type="number" name="attr_fourthmax" value="0" />
-            <br />
-            <div style="margin-left: 15px" class="simple120">5th</div>
-            <br />
-            <input type="number" name="attr_fifth" value="0" />/<input type="number" name="attr_fifthmax" value="0" />
-            <br />
-            <div style="margin-left: 15px" class="simple120">6th</div>
-            <br />
-            <input type="number" name="attr_sixth" value="0" />/<input type="number" name="attr_sixthmax" value="0" />
-        </div>
-        <div style="margin:-3px" class="inlinespell">
-            <div style="margin-left: 15px" class="simple120">7th</div>
-            <br />
-            <input type="number" name="attr_seventh" value="0" />/<input type="number" name="attr_seventhmax"
-                value="0" />
-            <br />
-            <div style="margin-left: 15px" class="simple120">8th</div>
-            <br />
-            <input type="number" name="attr_eighth" value="0" />/<input type="number" name="attr_eighthmax" value="0" />
-            <br />
-            <div style="margin-left: 15px" class="simple120">9th</div>
-            <br />
-            <input type="number" name="attr_ninth" value="0" />/<input type="number" name="attr_ninthmax" value="0" />
-        </div>
+        <span class="simple120">Spell Power</span>
+        <input type="number" name="attr_spellpower" value="0" />
+        <br />
+        <span class="simple120">Mana</span>
+        <input type="number" name="attr_mana" value="0" />/<input type="number" name="attr_manamax" value="0" />
         <br />
 
         <h3>Spell Proficiencies</h3>

--- a/roll20/rollapi.js
+++ b/roll20/rollapi.js
@@ -36,42 +36,69 @@ var FarhomeDice = FarhomeDice || (function () {
 
     var templateBtn = "background-color: transparent; padding: 0px; display: inline-block; color: black; border: 0.5px solid";
 
-    var spellText = {
-        "cold-snap": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: ["Sap the heat from a target. Make a spellcasting roll vs the targets stamina. On hit the target takes a wound. For every crit roll you the target gains a level of Slow until the end of their next turn.", "Add a proficiency die for every level above cantrip."] },
-        "firebolt": { dmg: [1, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1], txt: ["Blast a target with a bolt of fire. Make a spellcasting roll against the targets defense. On hit the target takes a wound, adding a wound die on crit.", "Add a wound die for every level above cantrip."] },
-        "message": { dmg: [], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: ["You attempt to send a telepathic message to a target you know. Make a spellcasting roll, adding a bad die for every 10 tiles you want the spell to travel, with a minimum of 1 bad die. On success the message is successfully broadcast. You know if the target recieved the message or not.", "Add a proficiency die for every level above cantrip."] },
-        "minor-image": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "static-shock": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "thundering-blow": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "arcane-blasts": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "arcane-key": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "beam-of-fire": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "call-lightning": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "chilling-ray": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "detect-magic": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "identify": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "magic-sight": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "poison-trap": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "ray-of-sickness": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "sword-burst": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "thunderclap": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "barrier": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "combust": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "dispel-magic": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "elemental-shell": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "flurry": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "imprint": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "magic-weapon": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "misty-step": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "resilient-shield": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "animate-guardian": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "chain-lightning": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "counter-spell": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "far-sight": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: [] },
-        "fireball": { dmg: [2, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1], txt: ["shoot a ball of fire centered at a target location you can see. The fireball explodes on impact, hitting all creatures in a 5x5 area. Creatures must make a Dexterity save vs your spellcasting, taking 1 wound on success. On failure they take 2 wounds, plus a wound die on crit.", "Add a wound die for every level above 3rd."] },
-        "flight": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: ["Gain magical flight, allowing you to float through the air. Target up to 5 willing creatures, adding a Terrible die to the spellcasting roll for each creature targeted. On success all targeted creatures gain a flying speed equal to their movement speeds.", "Add a proficient die for every level above 3rd."] },
-        "phantasmal-blades": { dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0], txt: ["Launch a series of arcane swords at a target. The target makes a Strength save vs your spellcasting, taking 3 wounds on fail.", "Add a wound and proficiency die for every level past 3rd."] },
+    var spellInfo = {
+        "cold-snap": { stat: "int", prof: "arcane", level: 0, ap: 5, range: 1, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Sap the heat from a target. Make a spellcasting roll vs the targets stamina. On hit the target takes a wound. For every crit roll you the target gains a level of Slow until the end of their next turn.", "Add a proficiency die for every level above cantrip."] },
+        "firebolt": { stat: "int", prof: "arcane", level: 0, ap: 6, range: 8, dmg: [1, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0], txt: ["Blast a target with a bolt of fire. Make a spellcasting roll against the targets defense. On hit the target takes a wound, adding a wound die on crit.", "Add a wound die for every level above cantrip."] },
+        "message": { stat: "int", prof: "arcane", level: 0, ap: 2, range: 10, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You attempt to send a telepathic message to a target you know. Make a spellcasting roll, adding a bad die for every 10 tiles you want the spell to travel, with a minimum of 1 bad die. On success the message is successfully broadcast. You know if the target recieved the message or not.", "Add a proficiency die for every level above cantrip."] },
+        "minor-image": { stat: "int", prof: "arcane", level: 0, ap: 4, range: 10, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You create a small, soundless illusory image no larger than 1 tile at a point within range. The image has no physical presence and objects pass through it as if it wasn't there. Any creature attempting to see through the illusion must make a perception check against your spellcasting, seeing the illusion for what it is on success. A creature that touches or passes through the illusion automatically passes this check.", "Add a proficiency die for every level above cantrip."] },
+        "static-shock": { stat: "int", prof: "arcane", level: 0, ap: 6, range: 3, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Charge the air around the target. Make a spellcasting roll vs the targets Dexterity. On success the target takes a wound. If you roll a crit the spell bounces to a creature adjacent to the target, making a new roll for the new target. This spell ends when you do not roll a crit or you run out of targets. This cannot effect the same target twice.", "Add a proficiency die for every level above cantrip."] },
+        "thundering-blow": { stat: "int", prof: "arcane", level: 0, ap: 5, range: 0, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["conjure a rolling thunder to blast a target away. Make a spellcasting roll vs the targets Strength. On hit, roll a wound die and the target is pushed back 1 tile and is staggered until the end of their next turn, being pushed an additional tile for every crit. If the target is unable to move, either due to another creature or obstacle, roll a wound die for every tile remaining.", "Add a proficiency die for every level above cantrip."] },
+        "arcane-blasts": { stat: "int", prof: "arcane", level: 1, ap: 8, range: 7, dmg: [0, 3], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0], txt: ["You shoot a volley of 2 force blasts, sending a blast to any target in range. The blasts travel around corners and obstacles, homing in on their target. You may have all blasts target the same creature, or split the blasts between creatures. The target creatures make a Strength save vs your spellcasting roll. On fail they take 1 wound die for every blast aimed at them, upgrading a wound die to a wound for every crit rolled.", "Add a blast (and wound die) for every level above the first."] },
+        "arcane-key": { stat: "int", prof: "arcane", level: 1, ap: 30, range: 0, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Magically force a lock to open. Make a lockpicking roll, using your spellcasting roll instead of your lockpicking skill. On success the lock is opened. This spell can open magical locks.", "Add a proficiency die for every level above 1st."] },
+        "beam-of-fire": { stat: "int", prof: "arcane", level: 1, ap: 7, range: 0, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 1, 0], txt: ["A blast of fire shoots from your hands, hitting all creatures in a 3x1 beam. Make a spellcasting roll vs the targets defense. On hit the target takes a wound, if you crit the targets take another wound.", "A blast of fire shoots from your hands, hitting all creatures in a 3x1 beam. Make a spellcasting roll vs the targets defense. On hit the target takes a wound, if you crit the targets take another wound."] },
+        "call-lightning": { stat: "int", prof: "arcane", level: 1, ap: 7, range: 10, dmg: [1, 2], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Call a bolt of lightning to strike a nearby target. The target makes a Dexterity save vs your spellcasting. On hit they take 1 wound, plus 2 wound dice in damage, and are paralyzed until the end of their next turn on crit. If cast in rainy conditions this spell only costs 5 AP.", "Add a proficiency die for every level above first."] },
+        "chilling-ray": { stat: "int", prof: "arcane", level: 1, ap: 6, range: 5, dmg: [0, 1], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You shoot a chilling beam at up to 3 targets in range. Make a spellcasting roll vs the targets Stamina. On hit, the target takes 1 wound die and gains Slow 1, or Slow 2 on crit.", "Add a proficiency die for every level above 1st."] },
+        "detect-magic": { stat: "int", prof: "arcane", level: 1, ap: 6, range: 10, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Target a 10x10 area, making a spellcasting roll against 2 bad die. On success you can see a faint outline over any magical effect in the area. For each crit you are able to determine the school of a given magic effect and a rough idea of the magic's purpose.", "Add a proficiency die for every level above the 1st."] },
+        "identify": { stat: "int", prof: "arcane", level: 1, ap: 30, range: 0, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Attempt to learn the secrets of a magical item or trinket. When attempting to identify an item, use your spellcasting instead of your Lore skill to make the roll.", "Add a proficiency die for every level above 1st"] },
+        "magic-sight": { stat: "int", prof: "arcane", level: 1, ap: 10, range: 0, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Create an invisible floating eye, visible only to those who can see the etheral plane or have cast Detect Magic. You can see, but not hear, everything the eye can see in addition to your normal senses. You can command the eye to move, moving 5 tiles each turn. If the eye moves more than 10 tiles away from you, you must make a spellcasting roll against 2 Bad die, repeating this roll every minute. On fail the spell ends. The eye cannot move through solid objects, but can fit through holes as small as 1 inch.", "If the eye is able to fully spot a creature behind cover, they gain 1 less bonus die from cover against your attacks.", "Add a proficiency die for every level above 1st."] },
+        "poison-trap": { stat: "int", prof: "arcane", level: 1, ap: 7, range: 5, dmg: [1, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Choose 3 connected tiles in range. When a creature starts their turn or enters a tile for the first time they must make a Stamina save against your spellcasting. On a fail they take 1 wound. On a crit the target is poisoned until the end of their next turn. These tiles count as difficult terrain, and last for 1 minute.", "Add a tile for every level above first."] },
+        "ray-of-sickness": { stat: "int", prof: "arcane", level: 1, ap: 5, range: 7, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Make a spellcasting roll vs a targets stamina. On success the target gains Poison 1 for the next 10 minutes, gaining a level for every crit.", "Add a target for every level above 1st."] },
+        "sword-burst": { stat: "int", prof: "arcane", level: 1, ap: 3, range: 0, dmg: [0, 1], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0], txt: ["Magically enchant your weapon to fire a burst of energy with your next attack. You gain Reach 1 for the duration of the spell. On your next attack the target makes a Strength save against your weapon attack roll. On fail, you connect with the attack, converting all physical damage to Force damage and adding an extra wound die to the damage roll. After you make the attack the spell ends.", "Your reach increases by 1 and you add a wound die to the damage for every level above the 1st."] },
+        "thunderclap": { stat: "int", prof: "arcane", level: 1, ap: 5, range: 0, dmg: [1, 1], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["A wave of force slams the ground around you, hitting all creatures adjacent to you. Make a spellcasting roll vs the targets defense. On hit the target takes a wound and a wound die in damage and is staggered, and on a crit the target is pushed away 1 tile from you, taking an extra wound if an object or creature blocks their movement.", "Add a proficiency die for every level above first."] },
+        "barrier": { stat: "int", prof: "arcane", level: 2, ap: 2, range: 0, dmg: [0, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["As a reaction you quickly pull up magical defenses, protecting you and all creatures adjacent to yourself. Make a spellcasting roll, you and all effected creatures add 1 superior die, adding an extra superior die for every crit, against the incoming spell. If the spell does not require a save, roll the superior dice against the casters spellcasting roll. On a success the spell has no effect.", "Increase the range of protection by 1 and add a proficiency die for every level above the first."] },
+        "combust": { stat: "int", prof: "arcane", level: 2, ap: 7, range: 10, dmg: [1, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Cause up to 2 creatures in range to burst into flames. Targets makes a Dexterity save vs your spellcasting, on a fail they ignite in flames. At the start of their turn they take 1 wound. On their turn they may spend 5 AP rolling on the ground to extinguish the fire, leaving them prone.", "Add a target for every level above 2nd."] },
+        "dispel-magic": { stat: "int", prof: "arcane", level: 2, ap: 5, range: 5, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You attempt to dispel a magical effect targeting a creature or area. Make a spellcasting roll vs 1 proficient die per level of spell you are trying to dispel. If the effect you are trying to break is actively being concentrated on by another creature make a spellcasting roll vs the creatures concentration instead. On success the magical effect ends. If targeting an effect caused by an object, such as a magic item or animated armor, they regain their magical effects after 10 minutes.", "You may target an additional effect for every level past 2nd."] },
+        "elemental-shell": { stat: "int", prof: "arcane", level: 2, ap: 5, range: 0, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Create an energy barrier around yourself. Choose a damage type: fire, cold, lightning, thunder, poison. Make a spellcasting roll, gaining Resistance 1 to that damage type, increasing the resistance by 1 for every crit rolled.", "Add a proficiency die for every level above 2nd."] },
+        "flurry": { stat: "int", prof: "arcane", level: 2, ap: 7, range: 0, dmg: [0, 2], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0], txt: ["You conjure a flurry of ice shards in a 3x3 area. Each creature must make a Stamina save vs your spellcasting modifier. On fail they take 2 wound die, gaining 1 level of Slow for the next minute on crit.", "Increase the number of wound dice and area by 1 for every level above 2nd."] },
+        "imprint": { stat: "int", prof: "arcane", level: 2, ap: 0, range: 0, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: [] },
+        "magic-weapon": { stat: "int", prof: "arcane", level: 2, ap: 10, range: 5, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Temporarily enchant a weapon with magic. Target up to 5 weapons, adding 1 terrible die to your spelclasting roll for each weapon targeted. On success the weapons are considered +1 magic weapons. If you lose or drop concentration before the hour is finished the weapons retain the magic for 1 minute before fading completely.", "Add a proficiency die for every level above 2nd."] },
+        "misty-step": { stat: "int", prof: "arcane", level: 2, ap: 3, range: 5, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Teleport to a unoccupied point you can see in range. Make a spellcasting roll, adding 2 bad die if you attempt to teleport more than 5 tiles, with a max range of 10. On success you teleport to that position, preventing any opportunity attacks or attacks that trigger on entering someones zone of control.", "Add a proficiency die for every level above 2nd."] },
+        "resilient-shield": { stat: "int", prof: "arcane", level: 2, ap: 4, range: 0, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["On your turn, or as a reaction, you create a dampening shield around yourself. While the shield holds you gain Resistance 1 to all physical damage. Make a spellcasting roll, the shield can take 3 hits before shattering, adding a hit for each crit rolled. While the spell is active you cannot take the move or sprint actions, but movement effects do not break the spell.", "Add a proficiency die for every level above 2nd."] },
+        "animate-guardian": { stat: "int", prof: "arcane", level: 3, ap: 10, range: 0, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You attempt to animate a simple object made of plant, wood, stone, or metal no more than 1 tile in size. If the object is part of a larger construction (a stone wall, a dirt mound, etc) you add 1 terrible die to your roll as you try to force it free.", "Make a spellcasting roll adding 2 terrible dice or 4 terrible dice if the meterial is metal. On success you create a golem out of the object. The golem has 3 wounds and acts on your turn. It can take a move action to move 4 tiles and can make a single attack. The golem's attack uses 5 normal dice, improing one die for every success and adding a die for every crit. The creature deals 1 wound on hit, adding a wound die for every size increase. After the duration or if the caster is incapacitated the golem reverts to inanimate material. Golems made of metal have Resistance 1 to physical damage.", "Add a proficient die for every level above 3rd. At 5th level you may target a 2x2 area creating a golem with 5 wounds, and at 7th a 3x3 area creating a golem with 8 wounds and two attacks per turn."] },
+        "chain-lightning": { stat: "int", prof: "arcane", level: 3, ap: 7, range: 5, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["A burst of lightning that bounces from target to target. The Lightning bounces from your target to a creature of your choice within 3 tiles of the target, bouncing this way up to 2 times. The lightning cannot bounce to the same creature twice and must bounce to a creature if able. Each creature hit by the lightning must make a Dexterity save vs your spellcasting, on hit they take 1 wound in damage, plus a wound die for every crit rolled in your spellcasting roll.", "The number of bounces increases by 1 and you add a proficient die to your spellcasting roll for every level above 3rd."] },
+        "counter-spell": { stat: "int", prof: "arcane", level: 3, ap: 2, range: 5, dmg: [0, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Attempt to counter the flow of magic. As a reaction make a spellcasting roll vs the targets Intelligence, adding a terrible/superior die for every level this spell is below/above the target spell. On success the spell is countered."] },
+        "far-sight": { stat: "int", prof: "arcane", level: 3, ap: 10, range: 0, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["See far into the distance, bending your sight around obstacles. Choose a location in range, making a spellcasting roll against 2 Terrible die, or 3 if the location is unfamiliar to you. On success you can see the target location as long as it is not complete incased, for example you would be able to see the happenings in a town, but not inside buildings. You can see the location as if you were present there, but cannot make out sounds. At any time you may change the target of your sight, requiring a minute to reorient yourself.", "Add a proficient die for every level above 3rd."] },
+        "fireball": { stat: "int", prof: "arcane", level: 3, ap: 8, range: 10, dmg: [2, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0], txt: ["shoot a ball of fire centered at a target location you can see. The fireball explodes on impact, hitting all creatures in a 5x5 area. Creatures must make a Dexterity save vs your spellcasting, taking 1 wound on success. On failure they take 2 wounds, plus a wound die on crit.", "Add a wound die for every level above 3rd."] },
+        "flight": { stat: "int", prof: "arcane", level: 3, ap: 7, range: 5, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Gain magical flight, allowing you to float through the air. Target up to 5 willing creatures, adding a Terrible die to the spellcasting roll for each creature targeted. On success all targeted creatures gain a flying speed equal to their movement speeds.", "Add a proficient die for every level above 3rd."] },
+        "phantasmal-blades": { stat: "int", level: 3, prof: "arcane", ap: 8, range: 10, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Launch a series of arcane swords at a target. The target makes a Strength save vs your spellcasting, taking 3 wounds on fail.", "Add a wound and proficiency die for every level past 3rd."] },
 
+        "bleed": { stat: "wil", prof: "curse", level: 0, ap: 5, range: 5, dmg: [0, 1], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Targeting a creature in range you can see you cause their wounds to reopen. The creature makes a Stamina save against your spellcasting roll. On fail they take 1 wound die in damage, or 3 wound dice if they have missing wounds.", "You may target an extra creature for every level cast above cantrip."] },
+        "eldritch-blast": { stat: "wil", prof: "curse", level: 0, ap: 5, range: 8, dmg: [1, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Blast a target with eldritch force. Make a spellcasting roll against the targets Strength. On success they take 1 wound, adding a wound die on crit.", "Add a proficiency die to your spellcasting roll for every level cast above cantrip."] },
+        "levitate": { stat: "wil", prof: "curse", level: 0, ap: 5, range: 5, dmg: [0, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You magically levitate an object or creature weighing less than 25 lbs. If the target is an unwilling creature you must make a spellcasting roll against thir Strength save. On success, each turn you may move the target 3 tiles upwards or downwards. This movement does not provoke opportunity attacks, and does not move them with enough force to damage them, but can force them prone (against the ceiling or floor).", "If the target is an unwilling creature they make the save again at the end of their turn, freeing themselves from your levitation on success. If the target is in the air when the spell ends it drops to the ground normally. If the target becomes heavier than the spell can carry (for example a creature standing ontop of a levitating slab) the spell ends.", "The maximum weight doubles for every level cast above cantrip."] },
+        "life-sense": { stat: "wil", prof: "curse", level: 0, ap: 5, range: 10, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["targeting a 4x4 cube, all living creatures give off the glow of life. Creatures must make a Willpower save vs your spellcasting. On a fail a dim light outlines their body. Any attacks against this creature can change a normal die for a proficiency die.", "Add a proficiency die to your spellcasting roll for every level cast above cantrip."] },
+        "trickery": { stat: "wil", prof: "curse", level: 0, ap: 5, range: 5, dmg: [0, 1], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: [] },
+
+
+        "guidance": { stat: "cha", prof: "divine", level: 0, ap: 3, range: 2, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Target up to 5 creatures. Make a spellcasting roll, adding a bad die for every creature targeted. On a success, the creature can add a proficiency die to their next attack roll or damage-dealing spell roll. On crit they add a superiority die instead.", "Add a proficiency die for every level above cantrip."] },
+        "holy-protection": { stat: "cha", prof: "divine", level: 0, ap: 4, range: 2, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Target up to 5 creatures. Make a spellcasting roll, adding a bad die for every creature targeted. On success, The next die to roll a crit against this creature is ignored.", "Add a proficiency die for every level above cantrip."] },
+        "light": { stat: "cha", prof: "divine", level: 0, ap: 6, range: 5, dmg: [0, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You cause a small object no larger than a fist to emit a bright light. You may control the intensity of the light, from 1 emitting 1 tile of dim light up to 3 tiles of bright light and 3 tiles of dim light. You may double the lights intensity, doubling the lights range but must make a concentration check each turn to maintain this effect. While intensifying the light, any creatures that are sensitive to bright light add 1 terrible die to their attack rolls while in this spells bright light.", "When this light enters magical darkness you must make a spellcasting roll vs the spellcasting roll of the effect that created the darkness. You add a superior or terrible die for every level above or below this light spell is compared to the darkness. On success the darkness is dispelled, and on fail this spell ends.", "The range of both the maximum bright and dim light increases by 1 tile for every level above cantrip. At level 5 and above this light is considered sunlight."] },
+        "radiant-light": { stat: "cha", prof: "divine", level: 0, ap: 6, range: 5, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["A ray of radiant light blasts a target creature in range. The creature makes a dexterity save vs your spellcasting. On a fail they take 1 wound, or 2 wounds if they are undead.", "Add a target for every level above cantrip."] },
+        "spare-from-death": { stat: "cha", prof: "divine", level: 0, ap: 4, range: 0, dmg: [0, 0], lroll: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Magically slow the heart and prevent blood loss. Make a Medicine check using your spellcasting for the roll, adding a bad die for every temporary wound missing. On success the target is stabilized and will regain consciousness in 10 minutes.", "Add a superior die for every level above cantrip."] },
+        "vine-whip": { stat: "cha", prof: "divine", level: 0, ap: 5, range: 5, dmg: [0, 1], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0], txt: ["Magically influence a plant to attack or grapple a nearby creature. Choose a location in range to grow a plant, or take control of a small or larger plant within 10 tiles. The plant grows a bramble whip it can use to attack creatures in melee range. You may use the plant to make an attack or grapple roll, using your spellcasting roll for the attack. On hit they take 1 wound die in damage, or 1 wound on crit.", "The plant lasts for 1 minute after which it returns to its original shape.", "Add a wound die for every level above cantrip."] },
+        "animal-messenger": { stat: "cha", prof: "divine", level: 1, ap: 30, range: 0, dmg: [0, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You attempt to summon a small beast to deliver a message for you. Make a spellcasting roll against 2 Terrible dice in an urban environment, or 2 Bad dice elsewhere. On success you summon a small beast local to the area, with the beast having wings on crit. You can give the beast a message up to 1 minute long and a description of who to deliver the message to. The beast will give the message to the first creature it finds that matches the description, and may have trouble with overly complex messages.", "On delivering the message the recipeint is able to give a 1 minute message in return. If the beast is unable to find a creature matching that description or unable to return the response within the spells duration the beast reverts back to a normal animal and the message is lost.", "The duration increases by 1 day for each level above the 1st."] },
+        "bonfire": { stat: "cha", prof: "divine", level: 1, ap: 30, range: 0, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You create a magical soothing bonfire. The bonfire takes a single tile of space, emits bright light for 5 tiles, and dim light for an additional 5. Target up to 5 creatures and make a spellcasting roll, adding a bad die for every creature targeted. These creatures heal an additional wound during their long rest and recover 1 point of exhaustion.", "Add a proficient die for every level above the 1st."] },
+        "bramble": { stat: "cha", prof: "divine", level: 1, ap: 7, range: 7, dmg: [0, 1], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["A growth of razor sharp bramble appears at a target location. Choose a point in range, summoning bramble in a 3x3 square centered on that point. The bramble counts as difficult terrain. The bramble is flammable and a tile will burn away after taking 1 wound of fire damage.", "Any creature attempting to take a move or sprint action through the bramble must make a Dexterity save vs your spellcasting. On fail they take 1 wound die, with their movement ending on a crit. A creature makes this save only once per move or sprint action.", "The area increases by 1 for every level above 1st."] },
+        "chilling-fog": { stat: "cha", prof: "divine", level: 1, ap: 6, range: 15, dmg: [0, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["A chilling fog appears in a 5x5 area at a target location. Make a spellcasting roll, all creatures gain slow equal to the number of crits rolled, with a minimum of 1. All creatures inisde the fog gain fire resistance 1. The fog heavily obscures the area.", "The size and range of the fog increase by 2 for every level above 1st."] },
+        "close-wound": { stat: "cha", prof: "divine", level: 1, ap: 5, range: 0, dmg: [1, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 1, 0], txt: ["Mend a creature's wounds. Make a spellcasting roll, healing a single wound and adding a wound for every crit rolled.", "Add a Wound die for every level above the 1st."] },
+        "healing-word": { stat: "cha", prof: "divine", level: 1, ap: 4, range: 5, dmg: [0, 0], lroll: [0, 0, 1, 0, 0, 0, 0, 0, 0, 0], txt: ["Send healing energy to a single target. Make a spellcasting roll, adding 3 Bad dice. On success, roll a wound die for every success rolled, healing for the total wounds rolled.", "Add a normal die for every level above the 1st."] },
+        "holy-weapon": { stat: "cha", prof: "divine", level: 1, ap: 4, range: 0, dmg: [0, 1], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Enchant your weapon with holy power. For the next minute you may use your divine spellcasting in place of attack rolls you make. Your attacks add an additional wound die to the damage, or 3 if the target is undead.", "Duration increases by 1 minute for every level cast above 1st."] },
+        "solar-flash": { stat: "cha", prof: "divine", level: 1, ap: 6, range: 0, dmg: [0, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Shine blinding light in a cone infront of you. A cone of light 3 tiles long shines from you. Each creature must make a Stamina save vs your spellcasting, on fail they are blinded until the end of their next turn. If the creature is sensitive to daylight or bright light they also take 1 wound in Holy damage.", "The the length of the cone increases by 1 for every level above 1st."] },
+        "tremor": { stat: "cha", prof: "divine", level: 1, ap: 7, range: 0, dmg: [0, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You cause the earth around you to tremor. All creatures within 2 tiles of you must make a Strength save vs your spellcasting. On fail the creature takes 1 wound die in damage, getting knocked prone on crit. If the ground in the area is loose earth or stone it becomes difficult terrain until cleared.", "The the effected tiles extends by 1 in all directions for every level above 1st."] },
+        "cleanse": { stat: "cha", prof: "divine", level: 2, ap: 3, range: 3, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Attempt to remove negative effects from a target. You may choose any number of conditions this spell can remove, adding a bad die to your spellcasting roll for each condition, and a bad die for every condition level above 1. On success, those conditions are removed from the target. Cleanse can remove Slow, Poison, Hex, Daze, Stun, Blind, and Fear.", "Add a proficiency die for every level above the 1st."] },
+        "consecrate-ground": { stat: "cha", prof: "divine", level: 2, ap: 10, range: 0, dmg: [1, 0], lroll: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Mark a 3x3 area centered on yourself, purifying the ground. Any undead or monstrosity attempting to enter the consecrated ground must make a Charisma save vs your spellcasting. On fail they cannot willingly enter. Any undead inside the consecrated ground takes 1 wound at the start of their turn. Allies inside the zone gain 1 proficiency on all saving throws. You may move normally, however leaving the area ends the spell. If the spell lasts for the full 10 minutes the area remains consecrated for 1 day.", "The area increases by 2 for every level cast above 2nd"] },
+        "enhance-ability": { stat: "cha", prof: "divine", level: 2, ap: 5, range: 3, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["Target up to 5 creatures. Make a spellcasting roll adding 1 terrible die, plus a terrible die for every creature targeted. On success the creatures gain +1 to a single attribute for the duration of the spell. They also gain +1 to their proficiency modifier in that attributes saving throw for every crit rolled.", "Add a proficiency die for every level above the 1st."] },
+        "gust": { stat: "cha", prof: "divine", level: 2, ap: 7, range: 0, dmg: [0, 1], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: ["You cause strong winds to blow in a direction, 10 tiles long by 2 tiles wide. Each creature in the line must make a Strength save vs your spellcasting, on fail they are blown back 1 tile, plus an additional tile for every crit rolled. If they are unable to move due to a wall or obstacle they instead take 1 wound die in damage. Any creature moving against the direction of the wind must spend two tiles of movement for every tile moved. You may spend 2 AP to reverse the direction of the wind.", "Add a proficiency die for every level cast above 2nd."] },
+        "guidance": { stat: "cha", prof: "divine", level: 2, ap: 5, range: 5, dmg: [0, 0], lroll: [0, 1, 0, 0, 0, 0, 0, 0, 0, 0], txt: [] },
     }
 
     var commandListener = function () {
@@ -171,6 +198,9 @@ var FarhomeDice = FarhomeDice || (function () {
                 else if (command === 'rr') {
                     reroll(msgFrom);
                 }
+                else if (command === 'spell') {
+                    spell(msgFrom, params);
+                }
 
 
                 if (result != "") {
@@ -195,11 +225,48 @@ var FarhomeDice = FarhomeDice || (function () {
                 return msg.content;
             }
         },
+        
+        getDefaultMods = function() {
+            return {
+                bonus: [0,0,0,0,0,0,0,0,0,0]
+            };
+        },
 
         getMods = function (param) {
-            var modObj = {}
-            if (param.substring(0, 2) === 'kh') {
-                modObj.keepHighest = param.substring(2, param.length);
+            var modObj = {
+                bonus: [0,0,0,0,0,0,0,0,0,0]
+            };
+            if (param.substring(0, 1) === 'b') {
+                var vals = param.substring(1).split('-');
+                for (var i = 0; i < vals.length; i++) {
+                    if (vals[i].length < 2) {
+                        continue;
+                    }
+                    var sub1 = vals[i].substring(0, 0), sub2 = vals[i].substring(0, 1);
+                    if (sub1 === 's' || sub1 === 'y') {
+                        modObj.bonus[0] += parseInt(vals[i].substring(1));
+                    } else if (sub1 === 'p' || sub1 === 'g') {
+                        modObj.bonus[1] += parseInt(vals[i].substring(1));
+                    } else if (sub1 === 'n' || sub1 === 'w') {
+                        modObj.bonus[2] += parseInt(vals[i].substring(1));
+                    } else if (sub1 === 'b' || sub1 === 'r') {
+                        modObj.bonus[3] += parseInt(vals[i].substring(1));
+                    } else if (sub1 === 't') {
+                        modObj.bonus[4] += parseInt(vals[i].substring(1));
+                    } else if (sub2 === 'pr') {
+                        modObj.bonus[5] += parseInt(vals[i].substring(2));
+                    } else if (sub2 === 'sd') {
+                        modObj.bonus[6] += parseInt(vals[i].substring(2));
+                    } else if (sub1 === 'd') {
+                        modObj.bonus[7] += parseInt(vals[i].substring(1));
+                    } else if (sub2 === 'gw') {
+                        modObj.bonus[8] += parseInt(vals[i].substring(2));
+                    } else if (sub1 === 'w') {
+                        modObj.bonus[9] += parseInt(vals[i].substring(1));
+                    } else if (sub1 === 'h') {
+                        modObj.bonus[10] += parseInt(vals[i].substring(1));
+                    }
+                }
             }
             return modObj;
         },
@@ -211,6 +278,7 @@ var FarhomeDice = FarhomeDice || (function () {
             return attr;
         },
         getAttrDice = function (attribute, proficiency, allowNegatives = true) {
+            log(attribute + " " + proficiency);
             var attributeUnder5 = Math.min(5, attribute);
             var attributeOver5 = Math.max(0, attribute - 5);
             var proficiencyOver5 = Math.max(0, proficiency - 5);
@@ -291,28 +359,24 @@ var FarhomeDice = FarhomeDice || (function () {
         },
 
         skillRoll = function (params) {
-            var modObj = params.length > 3 ? getMods(params[3]) : {};
+            var modObj = params.length > 3 ? getMods(params[2]) : getDefaultMods();
             modObj.hex = character ? parseInt(getAttr("hex", 0).get("current")) : 0;
             var statVal = parseInt(params[0]);
             var statProf = parseInt(params[1]);
             var poison = character ? parseInt(getAttr("poison", 0).get("current")) : 0;
             var fear = character ? parseInt(getAttr("fear", 0).get("current")) : 0;
 
-            var expertise = params.length >= 2 ? parseInt(params[2]) : 0;
-
-            if (expertise == 1) {
-                modObj.keepHighest = modObj.keepHighest ? modObj.keepHighest + 3 : 3;
-            }
-
             var dice = getAttrDice(statVal, statProf);
             dice[4] += poison;
             dice[3] += fear;
+
+            log(dice);
 
             return roll(dice, modObj);
         },
 
         customRoll = function (params) {
-            var modObj = params.length > 5 ? getMods(params[5]) : {};
+            var modObj = params.length > 5 ? getMods(params[5]) : getDefaultMods();
             modObj.hex = character ? parseInt(getAttr("hex", 0).get("current")) : 0;
 
             var diceVals = [parseInt(params[0]), parseInt(params[1]), parseInt(params[2]), parseInt(params[3]), parseInt(params[4]), 0, 0, 0, 0, 0];
@@ -321,7 +385,7 @@ var FarhomeDice = FarhomeDice || (function () {
         },
 
         attack = function (params) {
-            var modObj = params.length > 5 ? getMods(params[5]) : {};
+            var modObj = params.length > 5 ? getMods(params[5]) : getDefaultMods();
             modObj.hex = character ? parseInt(getAttr("hex", 0).get("current")) : 0;
             var poison = character ? parseInt(getAttr("poison", 0).get("current")) : 0;
             var fear = character ? parseInt(getAttr("fear", 0).get("current")) : 0;
@@ -338,7 +402,7 @@ var FarhomeDice = FarhomeDice || (function () {
         initiative = function (msgFrom, params) {
             var diceVals = [parseInt(params[0]), parseInt(params[1]), parseInt(params[2]), parseInt(params[3]), parseInt(params[4]), 0, 0, 0, 0, 0];
 
-            var modObj = params.length > 5 ? getMods(params[5]) : {};
+            var modObj = params.length > 5 ? getMods(params[5]) : getDefaultMods();
             modObj.hex = character ? parseInt(getAttr("hex", 0).get("current")) : 0;
 
             var msg = roll(diceVals, modObj);
@@ -363,7 +427,7 @@ var FarhomeDice = FarhomeDice || (function () {
 
         defend = function (params) {
             var diceVals = [0, 0, 0, 0, 0, parseInt(params[0]), parseInt(params[1]), 0, 0, 0];
-            var modObj = params.length > 2 ? getMods(params[2]) : {};
+            var modObj = params.length > 2 ? getMods(params[2]) : getDefaultMods();
             modObj.hex = character ? parseInt(getAttr("hex", 0).get("current")) : 0;
 
             return roll(diceVals, modObj);
@@ -377,7 +441,7 @@ var FarhomeDice = FarhomeDice || (function () {
         },
 
         wound = function (params) {
-            var modObj = params.length > 2 ? getMods(params[2]) : {};
+            var modObj = params.length > 2 ? getMods(params[2]) : getDefaultMods();
             var diceVals = [0, 0, 0, 0, 0, 0, 0, parseInt(params[0]), parseInt(params[1]), 0];
             if (character) {
                 var weaken = parseInt(getAttr("weaken", 0).get("current"));
@@ -386,6 +450,7 @@ var FarhomeDice = FarhomeDice || (function () {
                     diceVals[0] = 0;
                 }
             }
+            log(modObj);
             return roll(diceVals, modObj);
         },
 
@@ -533,7 +598,7 @@ var FarhomeDice = FarhomeDice || (function () {
             for (var i = 0; i < diceVals.length; i++) {
                 if (diceVals[i] > 0) {
                     msg += "<span>";
-                    for (var t = 0; t < diceVals[i]; t++) {
+                    for (var t = 0; t < diceVals[i] + modObj.bonus[i]; t++) {
                         rollResult.d.push(i);
                         rollResult.r.push(false);
                         var rollVal = randomInteger(6) - 1;
@@ -542,16 +607,6 @@ var FarhomeDice = FarhomeDice || (function () {
                             msg += "<span style='background-color:" + allDice[i].clr + "; border: 1px solid;'>Hex!</span>";
                             modObj.hex--;
                         }
-                        // if (allDice[i].val[rollVal] <= allDice[i].rrthresh && modObj.keepHighest > 0) {
-                        //     var oldVal = rollVal;
-                        //     rollVal = randomInteger(6) - 1;
-                        //     modObj.keepHighest--;
-                        //     successes += allDice[i].val[rollVal];
-                        // //     crits += allDice[i].crit[rollVal];
-                        //     msg += "<div style='display:inline-block'>(<img src='" + allDice[i].roll[rollVal] + "' style='background-color:" + allDice[i].clr + "; border: 1px solid;'>" +
-                        //         "<img src='" + allDice[i].roll[oldVal] + "' style='background-color:" + allDice[i].clr + "; border: 1px solid; opacity: 0.25;'>)</div>";
-                        //     continue;
-                        // }
                         else {
                             rollResult.v.push(rollVal);
                             successes += allDice[i].val[rollVal];
@@ -570,7 +625,69 @@ var FarhomeDice = FarhomeDice || (function () {
             return msg;
         },
 
-        spell = function (params, character) {
+        spell = function (msgFrom, params) {
+            var values = {};
+            if (spellInfo[params[0]] === undefined) {
+                values.name = params[0];
+                values.effect = "Spell not listed. Either it's not coded or spelled incorrectly.";
+
+                var msg = makeTemplate(values);
+                sendChat(msgFrom, "/direct " + msg);
+                return;
+            }
+
+            var info = spellInfo[params[0]];
+            var modObj = getMods(params[params.length - 1]);
+            var dmg = [info.dmg[0], info.dmg[1]];
+            var level = parseInt(params[1]);
+            var levelDiff = level - info.level;
+            for (var i = 0; i < 7; i++) {
+                modObj.bonus[i] += info.lroll[i] * levelDiff;
+            }
+            dmg[0] += info.lroll[7] * levelDiff + modObj.bonus[7];
+            dmg[1] += info.lroll[8] * levelDiff + modObj.bonus[8];
+            modObj.bonus[7] = 0;
+            modObj.bonus[8] = 0;
+
+            if (level < info.level) {
+                values.name = params[0];
+                values.effect = "Did you enter the right level? Spell needs a minimum of " + info.level +", entered " + level;
+
+                var msg = makeTemplate(values);
+                sendChat(msgFrom, "/direct " + msg);
+                return;
+            }
+
+            //rebuild bonus dice to pass into skill roll
+            var prefix = ['y','g', 'w', 'r', 'pr', 'sd', 'd', 'gw', 'w', 'h'];
+            var bonus = "b";
+            var addDash = false;
+            for (var i = 0; i < modObj.bonus.length; i++) {
+                if (modObj.bonus[i] > 0) {
+                    if (addDash === true) {
+                        bonus += "-";
+                    } else {
+                        addDash = true;
+                    }
+                    bonus += prefix[i] + modObj.bonus[i];
+                }
+            }
+
+            values.name = params[0];
+            values.description = "Lv" + level + ", " + info.ap + "AP, " + (info.range != 0 ? "Range " + info.range : "Touch");
+            values.effect = "";
+            for (var i = 0; i < info.txt.length; i++) {
+                values.effect += info.txt[i] + (i !== info.txt.length - 1 ? "<br/><br/>" : "");
+            }
+            values.mana = level + (level >= 5 ? 1 : 0) + (level >= 8 ? 2: 0);
+
+            values.rollSpell = skillRoll([getAttr(info.stat, "0").get("current"), getAttr(info.prof, "0").get("current"), bonus]);
+            if (dmg[0] > 0 || dmg[1] > 0) {
+                values.rollDmg = wound([dmg[0].toString(), dmg[1].toString()]);
+            }
+            
+            var msg = makeTemplate(values);
+            sendChat(msgFrom, "/direct " + msg);
         };
 
     return {

--- a/rulesdoc.md
+++ b/rulesdoc.md
@@ -401,17 +401,20 @@ Finally, choose 2 of the following bonuses.
 Instead of using the rules above for attributes, your group may decide to roll your scores. For each attribute roll 1 Superior, 3 Normal, and 1 Terrible die, adding up the total successes. The minimum score for an attribute is -2, with any rolls below that counting as -2 for the roll.
 
 ### Starting Equipment.
-Depending on your background you may start with additional gear. All players start with an adventuring kit containing a bedroll, 10 days of rations, a fire starter and 50ft of rope. In addition you start with 50 gold which you can spend on gear or upgrades. Any unspent gold becomes your characters starting money.
+Depending on your background you may start with additional gear. All players start with an adventuring kit containing a bedroll, 10 days of rations, a fire starter and 50ft of rope. In addition you start with 50 silver which you can spend on gear or upgrades. Any unspent silver becomes your characters starting money.
+
+#### Currency
+Currency in Farhome is divided into 3 types: the copper trite, silver cross, and platinum talent. An iron cross is worth 100 copper trites, and a platinum talent is worth 100 silver crosses.
 
 | Cost | Upgrade |
 |:----:|:-------------|
-| 5g  | Buy any simple weapon. |
-| 10g | Cantrip or Level 1 Spell |
-| 10g | Basic Healing Potion |
-| 10g | Buckler |
-| 15g | Padded or Studded armor. |
-| 15g | any martial weapon. |
-| 20g | Upgrading armor to the next type |
+| 5sc  | Buy any simple weapon. |
+| 10sc | Cantrip or Level 1 Spell |
+| 10sc | Basic Healing Potion |
+| 10sc | Buckler |
+| 15sc | Padded or Studded armor. |
+| 15sc | any martial weapon. |
+| 20sc | Upgrading armor to the next type |
 
 ### Leveling Up
 
@@ -477,7 +480,7 @@ Each turn your action points are refilled. You can spend any amount of AP on you
 #### Attack (5 AP)
 Make a single weapon attack against a target creature. The actual damage, range, and effects of an attack depend on the individual weapon. Unarmed attacks use Strength and use a wound die to determine if the attack deals damage.
 
-To make an attack you must succeed an attack roll vs the targets defense. You roll normal dice equal to your Strength/Dexterity, depending on what attribute the weapon uses. If you are proficient, improve a number of normal dice to proficient dice equal to your proficiency. If you have more successes vs the targets defense you hit. Draws are in favor of the defender.
+To make an attack you must succeed an attack roll vs the targets defense. If you have more successes vs the targets defense you hit. Draws are in favor of the defender.
 
 ##### Grapple
 Instead of making an attack you can attempt to grapple a creatrure. Make an atheletics check against a creatures Strength or Dexterity save, their choice. On success the creature is grappled. While grappling a creature your move and sprint speed are reduced to 1 and cannot be increased, however the grappled creature is dragged with you.
@@ -506,7 +509,7 @@ The default for using an item, drinking a potion, activating a magic item, or in
 You can use potions on willing or downed creatures by spending 5 AP instead of 2. Normal potion rules still apply.
 
 #### Spell (Varying AP)
-There is no limit to the number of spells you can cast, as long as you have enough AP to cast them. Most spells will require you to make a Spellcasting roll. These use normal dice equal to the spells spellcasting attribute: either Intelligence, Willpower, or Charisma. If you are proficient in that spell type, improve a number of normal dice to proficient dice equal to your proficiency modifier.
+There is no limit to the number of spells you can cast, as long as you have enough AP to cast them. Most spells will require you to make a Spellcasting roll against the targets defense or saving throw, with ties going in favor of the defender.
 
 
 #### Maneuver (Varying AP)
@@ -1191,7 +1194,7 @@ ___
 - **Range:** Self
 - **Duration:** concentration, 5 minutes
 
-Attempt to record your senses to an object, allowing a creature to replay your recording by holding the object and speaking a command word. Make a spellcasting roll, adding a superior die if a gemstone worth at least 50g is used. Depending on your successes the quality of the recording will change:
+Attempt to record your senses to an object, allowing a creature to replay your recording by holding the object and speaking a command word. Make a spellcasting roll, adding a superior die if a gemstone worth at least 50sc is used. Depending on your successes the quality of the recording will change:
 
 - **0-1**: There is no sound, and the visuals are too blurry to make out faces, but you can make out the type of area you are in.
 - **2-3**: You can determine each creatures race, but not face. You get a good idea of the area (in a cellar/building, number of trees, important PoI's such as a rock or pillar). You can hear if people are talking, but cannot make out words.
@@ -2112,7 +2115,7 @@ ___
 - **Range:** 5
 - **Duration:** concentration, 10 minutes
 
-Fill a targets mind with rage, forcing it to lash out against its surroundings. Make a spellcasting roll vs the targets Willpower. On success the target loses all remaining AP and makes a single attack against a random target within range. For every crit rolled the target improves a die for all attack rolls for the duration. On each of this creatures turns they must either attack a random target in range or move towards the closest creature. Each time this creature takes damage they make a willpower save against 2 bad die, adding a superior die for every wound taken.
+Fill a targets mind with rage, forcing it to lash out against its surroundings. Make a spellcasting roll vs the targets Willpower. On success the target loses all remaining AP and makes a single attack against a random target within range. For every crit rolled the target adds a normal die for all attack rolls for the duration. On each of this creatures turns they must either attack a random target in range or move towards the closest creature. Each time this creature takes damage they make a willpower save against 2 bad die, adding a superior die for every wound taken.
 
 Add a proficiency die for every level above the 2nd.
 
@@ -2272,7 +2275,7 @@ ___
 - **Range:** 5
 - **Duration:** concentration, 10 minutes
 
-Use your willpower to supress a creatures natural abilties. The target must make a willpower save, on fail you choose either Strength or Dexterity, the creature loses 2 to their proficiency modifier for all skills, saving throws, and weapon attacks using that attribute. Each crit further decreases the proficiency by 1. A creature with negative proficiency improves normal dice to bad dice instead of proficient dice.
+Use your willpower to supress a creatures natural abilties. The target must make a willpower save, on fail you choose either Strength or Dexterity, the creature loses 2 to their proficiency modifier for all skills, saving throws, and weapon attacks using that attribute. Each crit further decreases the proficiency by 1.
 
 Add a proficiency die for every level above 3rd.
 
@@ -3552,7 +3555,7 @@ You channel your divine magic to become an avatar of your deity. Make a spellcas
 
 - You gain a flying speed equal to your movespeed.
 - You gain Resistance 1 to all damage.
-- All proficiencies improve normal dice to superior dice.
+- You have expertise in everything.
 - You add 2 superior dice to all saving throws.
 
 ## Maneuvers
@@ -3954,18 +3957,18 @@ You gain proficiency in Divine spells. You gain 2 mana and start with a codex co
 
 #### Soldier
 You learn 1 maneuver you meet the requirements for and gain proficiency in 3 martial weapons. You may also choose one of the following trainings:
-- Shield Master: When attacked, you may spend 1 AP to reroll an attackers die, taking the new value.
-- Weapon Expert: Choose a weapon type, when making attacks with this weapon improve 1 proficient die to a superior die.
-- Defensive Stance: You may spend 1 AP reroll 1 defense die when making a defense roll
+- Shield Master: When attacked, as long as you are holding a shield you may spend 1 AP to reroll 2 of the attackers dice, taking the new values.
+- Weapon Expert: Choose a weapon type, when making attacks with this weapon you may reroll 1 die, taking the new value.
+- Defensive Stance: You may reroll 1 defense die when making a defense roll.
 - Ranger: + 2 to your attack range before penalities, and you take no penalties from attacking when someone is in your zone of control.
 You begin with Hide Armor, and 3 weapons you are proficient in.
 
 
 #### Noble
-You start with double starting gold and gain proficiency in a martial weapon. Your skill in trade and court proceedings allows you to improve 1 proficient die to a superior die for all charisma skills. You gain 5 proficiency points to spend among skills. You start with Padded armor and 1 martial weapon of your choice.
+You start with double the starting silver and gain proficiency in a martial weapon. Your skill in trade and court proceedings allows you to reroll 1 die for all charisma skills checks. You gain 5 proficiency points to spend among skills. You start with Padded armor and 1 martial weapon of your choice.
 
 #### Ranger
-Your time hunting and wandering through the wilderness has honed your skills. You gain 1 proficency with a ranged weapon, Nature, Survival and Animal Handling and your Move speed increases by 1 tile. In addition, you can improve 1 die to a superior die for initiative, Nature, Survival, and Animal Handling rolls. You start with Studded armor and 1 weapon of your choice.
+Your time hunting and wandering through the wilderness has honed your skills. You gain 1 proficency with a ranged weapon, Nature, Survival and Animal Handling and your Move speed increases by 1 tile. In addition, you can reroll 1 die when making an initiative, Nature, Survival, or Animal Handling roll. You start with Studded armor and 1 weapon of your choice.
 
 #### Street Urchin
 You gain 1 proficiency in Sleight of Hand, Stealth and Lockpicking and have expertise in those skills. Using the Hide action takes 1 less AP. You start with a simple weapon of your choice.
@@ -3997,7 +4000,7 @@ ___
 Choose 2 skill or tool proficiencies, You gain expertise in these skills.
 
 #### Duelist
-You gain a mastery of one handed weapons. When attacking with a one handed weapon your first weapon proficiency improvement uses a superior die. If you hold nothing in your off hand all your weapon proficiency uses superior die.
+You gain a mastery of one handed weapons. When attacking with a one handed weapon you may reroll 1 die. If you hold nothing in your off hand you have expertise with that weapon.
 
 #### Lucky
 When you make a roll, you may reroll up to your charisma worth of dice. This can be used twice, after which you must take a long rest to regain this feat.
@@ -4428,7 +4431,7 @@ A vial of poison, enough to coat a weapon for 3 attacks or 10 arrowheads. Poison
 | Poison | 0/1+ | They take an additional wound in poison damage and gain 1 + modifier levels of Poison for 1 hour. |
 | Toxin | 1/1+ | Roll 2 + modifier wound dice for the attack |
 | Paralyzing | 1+/0 | creature is paralyzed for 10 minutes |
-| Confounding | 1+/0 | creatures proficiency modifiers are reduced by 1 + modifier. Negative proficiencies 'improve' normal dice to bad dice. |
+| Confounding | 1+/0 | creatures proficiency modifiers are reduced by 1 + modifier. |
 
 ___
 ### Mundane Gear
@@ -4526,8 +4529,8 @@ A set of tools for picking a variety of locks. Anyone can use a lockpicking set,
 | Type | Bonus |
 |:----:|:-------------|
 | Basic  | None |
-| Expert  | Improves 1 proficient die to a superior die |
-| Masterwork | Improves 3 proficient dice to superior dice |
+| Expert  | Adds 1 proficient die. |
+| Masterwork | Adds 2 proficient dice |
 | Skeleton Key | Adds 4 superior dice to a lockpicking roll. After making the roll, roll a terrible die. The skeleton key breaks on fail. |
 
 ___
@@ -4673,8 +4676,6 @@ ___
   During a long rest you may attempt to enchant a single piece of mundane gear. Enchanted gear lasts for 3 days and count as magical equipment for the duration. After the Ehcantment ends the gear returns to being mundane. To enchant a piece of gear you must have mana available and enough enchanting supplies for the enchantment. Then you must pass the enchanting roll, with failure consuming the mana and supplies but not giving the enchantment. Most cities and towns will sell enchanting supplies.
   
   The enchanting roll uses your skill with your enchanters tools. You may spend additional mana, adding a proficient die for every 3 mana added. Ammunition loses it's enchantment on hit, whether the effect is triggered or not.
-
-  A creature can only use 1 piece of enchanted equipment at a time.
   
   ##### Enchantments
 | | Name | Mana | Supplies | Roll | Effect |
@@ -4712,16 +4713,16 @@ When copying spells from a Codex you can instead use your scribing tools to crea
 ##### Spell Scrolls
 | Level | Mana | Gemstones | Supplies | Challenge Dice |
 |:-----:|:-----:|:-----:|:-----:|:-------------|
-| Cantrip | 1 | 10gp gemstone | 0 | 1B |
-| 1st | 1 | 10gp gemstone | 1 | 1T |
-| 2nd | 2 | 25gp gemstone | 1 | 2T |
-| 3rd | 3 | 25gp gemstone | 2 | 3T |
-| 4th | 4 | 50gp gemstone | 2 | 4T |
-| 5th | 6 | 50gp gemstone | 3 | 5T |
-| 6th | 7 | 100gp gemstone | 4 | 6T |
-| 7th | 8 | 250gp gemstone | 5 | 7T |
-| 8th | 9 | 500gp gemstone | 7 | 8T |
-| 9th | 12 | 1000gp gemstone | 10 | 9T |
+| Cantrip | 1 | 10sc gemstone | 0 | 1B |
+| 1st | 1 | 10sc gemstone | 1 | 1T |
+| 2nd | 2 | 25sc gemstone | 1 | 2T |
+| 3rd | 3 | 25sc gemstone | 2 | 3T |
+| 4th | 4 | 50sc gemstone | 2 | 4T |
+| 5th | 6 | 50sc gemstone | 3 | 5T |
+| 6th | 7 | 100sc gemstone | 4 | 6T |
+| 7th | 8 | 250sc gemstone | 5 | 7T |
+| 8th | 9 | 500sc gemstone | 7 | 8T |
+| 9th | 12 | 10pt gemstone | 10 | 9T |
 
 #### Inscribing Runes
 You can inscribe a rune during a long rest or with 2 hours of downtime. To inscribe you need to have the required supplies and mana which are consumed in creating the rune. Runes are consumed on use, with some requiring a specific trigger to activate. Once triggered the rune is consumed regardless of the result. Unless otherwise stated, runes that agument spells require no AP to use while placing a rune takes 2 AP.
@@ -4729,8 +4730,8 @@ You can inscribe a rune during a long rest or with 2 hours of downtime. To inscr
 ##### Runes
 | Rune | Mana | Gemstones | Supplies | Challenge Dice | Effect |
 |:-----:|:-----:|:-----:|:-----:|:-----:|:-------------|
-| Longcaster | 1 | 1 10gp gemstone | 0 | 1B | Doubles the range of a spell that does not have a range of self or touch. |
+| Longcaster | 1 | 1 10sc gemstone | 0 | 1B | Doubles the range of a spell that does not have a range of self or touch. |
 | Potency | 1 | - | 1 | 2B | The first success in your spellcasting roll counts as a crit in addition to its dice value. |
 | Fire Ward | 2 | - | 1 | 1B/1T | Once placed, the next creature to enter its tile makes a Dexterity save vs 2 Superior dice, taking 1 wound and 1 wound die in fire damage on fail. |
 | Arc Ward | 2 | - | 1 | 1B/1T | Once placed, the next creature to enter its tile makes a Stamina save vs 2 Superior dice, becoming Paralyzed for 1 minute on fail. |
-| Expanding | 3 | 1 25gp gemstone | 1 | 2T | Increases the area effected by a spell by 1. |
+| Expanding | 3 | 1 25sc gemstone | 1 | 2T | Increases the area effected by a spell by 1. |

--- a/rulesdoc.md
+++ b/rulesdoc.md
@@ -27,12 +27,11 @@
 
 [Spells](#Spells)
 - [Spellbooks](#Spellbooks)
-- [Spell Slots](#Spell-Slots)
+- [Mana](#Mana)
 - [Preparing Spells](#Preparing-Spells)
 - [Casting Spells](#Casting-Spells)
 - [Concentration](#Concentration)
 - [Cantrips](#Cantrips)
-- [Spell Slots](#Spellbooks)
 
 [Creating a Character](#Creating-a-Character)
 - [Starting Equipment](#Starting-Equipment)
@@ -297,7 +296,7 @@ Weapon proficiencies are split between 4 categories: One Handed, Two Handed, Ran
 
 Spells are split into 3 schools: Arcane, Curse, and Divine. Each school handles a different type of spell and uses a different attribute for its spellcasting. Arcane spells use the elements and raw power to defeat their foes, using Intelligence for its attribute. Curse spells disable and debuff their targets and uses Willpower. Divine spells center around healing and buffing targets and uses Charisma.
 
-To cast a spell you must have a codex containing the spell you want to cast, have the spell prepared, and have a spell slot with a high enough level to cast the spell.
+To cast a spell you must have a codex containing the spell you want to cast, have the spell prepared, and have enough mana to cast the spell.
 
 ### Spellbooks
 
@@ -306,9 +305,18 @@ Very few creatures are able to innately cast magic. Almost everyone must prepare
 ##### Variant Rule - Spells from Codexes
 In some games spells may be limited, or codecies a rare occurance. With this variant when copying a spell from a codex, instead of destroying the codex you make an Arcana check against 2 bad dice. On success codex is not destroyed. Regardless a spell can only be copied once.
 
-### Spell Slots
+### Mana
 
-Casting spells of 1st level and above takes a toll on the caster, a character can only cast so many of these spells before needing to rest. To cast a spell you need a spell slot with a level equal to or greater than the spells level. Once a spell slot is used you cannot use that spell slot again until you complete a rest.
+Casting spells of 1st level and above takes a toll on the caster, a character can only cast so many of these spells before needing to rest. Your mana is consumed each time you cast a spell, and you cannot cast a spell if you do not have the mana to cast it. Spells cost 1 mana per level to cast, increasing in cost at certain levels. You recover mana after taking a short or long rest.
+
+| Spell Level | Mana |
+|:----:|:-------------|
+| 1st-4th | Spell level |
+| 5th-8th  | Spell level +1 |
+| 9th-10th | Spell level +3 |
+
+### Spell Power
+Spell power determines how attuned your body is to spellcasting and how easily it is to get mana. When leveling up you may choose to get mana based on your spell power. By default your spell power is equal to your characters level, and can be increased through leveling up or through feats.
 
 ### Preparing Spells
 
@@ -320,7 +328,17 @@ Once prepared spells are castable until the next day, even without your Codex. T
 
 Each spell has either an AP cost or a time given as its casting time. There is no limit to the number of spells you can cast a turn, as long as you have the AP to do so. Casting a spell that lists a time instead of AP can still be used in combat, but requires the casting time worth of full turns. For example casting a spell with a cast time of 1 minute requires 3 full turns to cast.
 
-All spells, including cantrips, can be cast at a higher level if you have a spell slot available. Casting spells this way give additional effects listed in the spell.
+All spells, including cantrips, can be cast at a higher level if you have enough mana available. When casting at a higher level you spend Mana equal to the level your casting at, not the spells base level. Casting spells this way give additional effects listed in the spell.
+
+Depending on your character's level you will only be able to cast, or up-cast, spells to a certain level. The table blow shows the maximum level your character can cast based on their level.
+
+| Player Level | Spell Level | Player Level | Spell Level |
+|:----:|:----:|:----:|:----:|
+| 1st  | 1st | 15th | 6th |
+| 3rd  | 2nd | 18th | 7th |
+| 6th | 3rd | 21st | 8th |
+| 9th | 4th | 24th | 9th |
+| 12th | 5th | 27th | 10th |
 
 ### Concentration
 
@@ -330,11 +348,11 @@ When you take damage while concentrating on a spell you must pass a Stamina save
 
 ### Cantrips
 
-Cantrips are spells that do not require a spell slot to cast, but must still be prepared like the rest of your spells. For casting at a higher level, cantrips are considered level 0 spells and gain benefits when even a 1st level spell slot is used to cast it.
+Cantrips are spells that do not require mana to cast, but must still be prepared like the rest of your spells. For casting at a higher level, cantrips are considered level 0 spells and gain benefits when even 1 mana is used to cast it.
 
 ### Variant Rule - Misfires
 
-While anyone can cast any spell they have a spell slot for, trying to cast a spell beyond your abilities can lead to a misfire. When casting a spell beyond your ability, either normally or through upcasting a different spell, you add 2 terrible die to the spellcasting roll for every rank beyond your ability. If you do not have any remaining successes before contesting with another roll the spell misfires. Roll on the misfire chart to determine the effect.
+While anyone can cast any spell they have the mana for, trying to cast a spell beyond your abilities can lead to a misfire. When casting a spell beyond your ability, either normally or through upcasting a different spell, you add 2 terrible die to the spellcasting roll for every rank beyond your ability. If you do not have any remaining successes before contesting with another roll the spell misfires. Roll on the misfire chart to determine the effect.
 
 ##### Ability Ranks
 | Attribute | Spell Levels |
@@ -352,7 +370,7 @@ Roll 2 bad dice, counting the successes.
 
 | Roll | Misfire |
 |:----:|:-------------|
-| -4  | Lesser Wound: Mana leak. Every time you take at least 1 wound you lose your lowest spell slot available. Lasts until cured with _Treat Injury_ or you take a Long Rest. |
+| -4  | Lesser Wound: Mana leak. Every time you take at least 1 wound you lose 2 mana. Lasts until cured with _Treat Injury_ or you take a Long Rest. |
 | -3 | Your spell backfires, roll a wound die for every remaining failure from your spellcasting roll, taking a wound for every wound rolled. |
 | -2 | Wild magic fills the area around you, you and all creatures within 3 tiles add 1 terrible die to their next roll |
 | -1 | Your flow of magic is interrupted, you add 1 terrible die to all spellcasting rolls for the next minute |
@@ -399,24 +417,24 @@ Depending on your background you may start with additional gear. All players sta
 
 When you earn 1000 experience your character levels up. Each level you gain 2 proficiency points and choose one of the following bonuses:
 
-- Gain up to 4 spell slots*
+- Gain 3 spell power. Gain mana based on your spell power below.*
 - Gain 4 proficiency points
 - Gain a Feat
 - Learn a Maneuver
 - Increase your max wounds by 1
 
-##### Spell Slots
-The sum total of spell slots gained each level cannot exceed twice your Spell level, and each spell slot cannot exceed your Spell level. 
+**Mana**
+When gaining mana, you apply the spell power gained from leveling up before adding mana from the chart below.
 
-For example, a 2nd level player has a spell level of 1, and so can gain 2 level 1 spell slots. A 4th level character can get 2 2nd level spell slots, or 1 2nd level and 2 1st, or 4 1st level spell slots.
-
-| Player Level | Spell Level | Player Level | Spell Level |
-|:----:|:----:|:----:|:----:|
-| 1st  | 1st | 15th | 6th |
-| 3rd  | 2nd | 18th | 7th |
-| 6th | 3rd | 21st | 8th |
-| 9th | 4th | 24th | 9th |
-| 12th | 5th | 27th | 10th |
+| Player Level | Spell Level |
+|:----:|:----:|
+| 1-8  | 3 |
+| 9-18  | 4 |
+| 19-28 | 5 |
+| 29-40 | 7 |
+| 41-55 | 9 |
+| 56-70 | 12 |
+| 70+ | 15 |
 
 
 #### Attribute Score increase
@@ -538,15 +556,11 @@ During the adventuring day you will sometimes need to take a rest to recover hea
 
 ### Short Rest
 
-Short rests require an hour of uninterrupted rest to complete. During a short rest you may spend any number of healing surges to restore lost wounds. 
-
-Spellcasters restore up to 1/3rd of their level, rounded up, in spell slots. You may restore any number of spell slots this way as long as the sum level is not greater than 1/3rd of your level.
+Short rests require an hour of uninterrupted rest to complete. During a short rest you may spend any number of healing surges to restore lost wounds. You regain mana equal to half your character's level, rounded up, with a minimum of 1.
 
 ### Long Rest
 
-Long rests require 8 hours of rest, with at most 2 hours of non-strenuous activity, such as keeping watch, preparing spells, brewing potions, etc. You automatically recover 1 wound and 3 healing surges over a long rest, and you may spend any number of healing surges to restore wounds.
-
-Spellcasters restore up to their level in spell slots. You may restore any number of spell slots this way as long as the sum level is not greater than your level. In addition you may prepare new spells for the day.
+Long rests require 8 hours of rest, with at most 2 hours of non-strenuous activity, such as keeping watch, preparing spells, brewing potions, etc. You automatically recover 1 wound and 3 healing surges over a long rest, and you may spend any number of healing surges to restore wounds. You regain mana equal to 3 + your character's level.
 
 ### Exhaustion
 All adventurers need to rest from time to time, trying to do too much in a day can leave you exhausted. You can gain exhaustion from many places, from travelling too long, not taking rests, spells, or abilities. At 6 levels of exhaustion you drop dead.
@@ -683,7 +697,7 @@ ___
 
 ##### Innate Magic
 
-You may learn a single cantrip, this cantrip does not require a codex to cast. On a short rest you recover an additional level worth of spell slots.
+You may learn a single cantrip, this cantrip does not require a codex to cast. You start with 1 extra mana and recover 1 extra mana each short and long rest.
 
 ___
 #### Wood Elf
@@ -3812,9 +3826,9 @@ ___
 - **Range:** Melee
 - **Level Required:** 3/12
 
-Empower your weapon with holy might. This attack consumes up to a 2nd level spell slot. Make a normal weapon attack, using your divine spellcasting proficiency instead of your weapon proficiency, adding a proficient die to the roll. On hit, the target takes normal weapon damage, plus 1 wound die per spell level used in holy damage. If the target is undead, they take wounds instead. On crit, if the target is undead they are turned for 1 minute.
+Empower your weapon with holy might. This attack consumes up to 2 mana. Make a normal weapon attack, using your divine spellcasting proficiency instead of your weapon proficiency, adding a proficient die to the roll. On hit, the target takes normal weapon damage, plus 1 wound die per mana used in holy damage. If the target is undead, they take wounds instead. On crit, if the target is undead they are turned for 1 minute.
 
-***Enhanced:*** Add a superior die instead of a proficient die to your attack roll, you may use up to 4th level spell slots.
+***Enhanced:*** Add a superior die instead of a proficient die to your attack roll, you may use up to 4 mana.
 
 ___
 #### Savage Leap
@@ -3845,7 +3859,7 @@ ___
 - **Range:** Weapon Range
 - **Level Required:** 4/16
 
-You channel magic into your weapon, empowering the next attack and consuming a spell slot. Make a weapon attack against a target adding 1 proficient die to the roll, on hit the target takes normal damage. Regardless of the outcome the arrow turns to energy and pierces through, hitting 2 tiles directly behind the target. Any creatures hit must make a defense roll vs your attack, taking a wound on hit. The arrow pierces 1 tile further per spell level consumed.
+You channel magic into your weapon, empowering the next attack and consuming up to 3 mana. Make a weapon attack against a target adding 1 proficient die to the roll, on hit the target takes normal damage. Regardless of the outcome the arrow turns to energy and pierces through, hitting 2 tiles directly behind the target. Any creatures hit must make a defense roll against your attack, taking a wound on hit. The arrow pierces 1 tile further per mana consumed.
 
 ***Enhanced:*** On crit, deal an additional wound die to all targets.
 
@@ -3930,13 +3944,13 @@ You bring the full weight of your weapon down on a target. Make a normal weapon 
 ### Backgrounds
 
 #### Magician's Apprentice
-You gain proficiency in Arcane spells. You gain 2 level 1 spell slot and start with a codex containing 4 cantrip or level 1 spells of your choosing. You gain 1 proficiency in Arcana and Lore.
+You gain proficiency in Arcane spells. You gain 2 mana and start with a codex containing 4 cantrip or level 1 spells of your choosing. You gain 1 proficiency in Arcana and Lore.
 
 #### Coven Witch
-You gain proficiency in Curse spells. You gain 2 level 1 spell slot and start with a codex containing 4 cantrip or level 1 spells of your choosing. You gain 1 proficiency Nature and apothecary tools.
+You gain proficiency in Curse spells. You gain 2 mana and start with a codex containing 4 cantrip or level 1 spells of your choosing. You gain 1 proficiency Nature and Apothecary Tools.
 
 #### Priest
-You gain proficiency in Divine spells. You gain 2 level 1 spell slot and start with a codex containing 4 cantrip or level 1 spells of your choosing. You gain 1 proficiency in Religion and Medicine.
+You gain proficiency in Divine spells. You gain 2 mana and start with a codex containing 4 cantrip or level 1 spells of your choosing. You gain 1 proficiency in Religion and Medicine.
 
 #### Soldier
 You learn 1 maneuver you meet the requirements for and gain proficiency in 3 martial weapons. You may also choose one of the following trainings:
@@ -3965,12 +3979,12 @@ You start with Scalemail Armor and a martial weapon of your choice.
 Either by circumstance or choice, your time in the pits has honed your senses in battle. You gain 1 proficiency in Unarmed fighting and 2 proficiency points for any martial weapons. While wearing light or no armor your sprint speed is increased by 1. When attacked by a creature inside your zone of control you may improve one defense die to a superior defense die.
 
 #### Chosen
-You are beholden to a greater power, either by choice or folly. For better or worse they have given you some of their power. Choose a cantrip or level 1 spell. Once per rest you may cast that spell without needing to prepare it or expend a spell slot, adding 1 superior die to the spellcasting roll. Spells cast this way are cast at your highest spell level. You may change your Chosen spell by spending a week of downtime, choosing a new spell at or below your spell level, and no higher than 5th level.
+You are beholden to a greater power, either by choice or folly. For better or worse they have given you some of their power. Choose a cantrip or level 1 spell. Once per rest you may cast that spell without needing to prepare it or expend mana, adding 1 superior die to the spellcasting roll. Spells cast this way are cast at your highest spell level. You may change your Chosen spell by spending a week of downtime, choosing a new spell at or below your spell level, and no higher than 5th level.
 
 You gain 1 proficiency with Lore, Religion, and Survival.
 
 #### Enchanter
-You have learned the trade of an enchanter, allowing you to empower mundane items. You gain 1 proficiency in Lore, Arcana, and Diplomacy, and Enchanting tools. Enchantments cost half as much when done by yourself, and you may use 2 pieces of enchanted gear instead of 1. You start with 2 level 1 spell slots.
+You have learned the trade of an enchanter, allowing you to empower mundane items. You gain 1 proficiency in Lore, Arcana, and Diplomacy, and Enchanting tools. Enchantments cost half as much when done by yourself, and you may use 2 pieces of enchanted gear instead of 1. You start with 2 mana.
 
 
 #### Disciple
@@ -4016,7 +4030,7 @@ You gain proficiency in Curse spells.
 You gain proficiency in Divine spells.
 
 #### Battle Mage
-If you cast a cantrip or 1st level spell, your next basic attack costs 2 less AP. The spell level increase to 2 at 7th level, and 3 at 15th level.
+If you cast a cantrip or 1st level spell, your next basic attack costs 2 less AP. The spell level increase to 2 at 7th level, and 3 at 15th level, and 4th at 25th level.
 
 #### Flurry of Blows
 After an unarmed attack, if you have nothing in your offhand you may take the Off-Hand attack action, making two unarmed attacks instead of one, each rolling a single wound for damage.
@@ -4098,7 +4112,7 @@ While not in direct sunlight you have expertise in stealth. While in dim light o
 #### Beast Speech
 *Requires Chosen, proficiency in Conversation*
 
-You can speak with animals and cast _Animal Messenger_ at 1st level without a codex and without spending a spell slot.
+You can speak with animals and cast _Animal Messenger_ at 1st level without a codex and without spending mana.
 
 
 #### Action Surge
@@ -4136,7 +4150,7 @@ If used again before a long rest, add a terrible die for every time this has bee
 #### Elemental Affinity
 *Requires proficiency with Arcane spells, 3 Intelligence*
 
-Your mastery of magic has enhanced your abilities with a given element. Choose fire, cold, lightning, thunder, or poison. Spells you cast of this element ignore 1 level of resistance and you add 1 superior die to those spells spellcasting roll. In addition you gain 1 superior die when making saving throws against spells with that damage type.
+Your mastery of magic has enhanced your abilities with a given element. Choose fire, cold, lightning, thunder, force, or poison. Spells you cast of this element ignore 1 level of resistance and you add 1 superior die to those spells spellcasting roll. In addition you gain 1 superior die when making saving throws against spells with that damage type.
 
 #### Evasion
 *Requires Agile, 3 Dexterity*
@@ -4149,9 +4163,9 @@ When targeted by a non-single target attack, maneuver, or spell you may spend up
 When you make a melee attack against a creature with a weapon you are proficient in, they cannot make opportunity attacks against you until the start of your next turn, regardless of the outcome of the attack. In addition, you add 1 superior defense die to opportunity attacks made while taking the move action, but not sprinting.
 
 #### Twinned Spell
-*Requires Proficiency with Arcane spells, 15th Level*
+*Requires 4 Proficiency with Arcane spells, 15th Level*
 
-When casting an Arcane spell you may cast a second copy of the spell, using another spell slot but costing no additional AP. The spells must have different targets, and creatures can only be affected by one of the two spells when their area of effect overlap. You use a single spellcasting roll for both spells, adding 2 terrible die to your roll.
+When casting an Arcane spell you may cast a second copy of the spell, using twice the mana but costing no additional AP. The spells must have different targets, and creatures can only be affected by one of the two spells when their area of effect overlaps. You use a single spellcasting roll for both spells, adding 1 Terrible die to your roll.
 
 #### Potent Curses
 *Requires Witch or Coven Witch, 3 Willpower*
@@ -4167,7 +4181,7 @@ You add 1 superior die when making Enchantment rolls. Enchantments you make last
 #### Mana Font
 *Requires 2 Intelligence*
 
-While in combat you may spend 3 AP to restore spell slots with a combined level equal to 1/3rd of your level, rounded up. After use, cannot be used again until taking a rest.
+While in combat you may spend 3 AP to restore mana equal to half your level, rounded up. After use, cannot be used again until taking a rest.
 
 #### Arcane Forge
 *Requires proficiency with Enchanters Tools*
@@ -4244,7 +4258,7 @@ Your are able to mend even the most fatal of wounds. When casting a healing spel
 #### Spellspeaker
 *Requires proficiency with Scribing Tools, Arcana*
 
-You may use spell scrolls to cast the spell written on them. When using a spell scroll you cast as normal, consuming a spell slot but not requiring the spell to be prepared. After casting the spell make an Arcana check against the spells inscribing difficulty. On fail the spell scroll is destroyed.
+You may use spell scrolls to cast the spell written on them. When using a spell scroll you cast as normal, consuming mana but not requiring the spell to be prepared. After casting the spell make an Arcana check against the spells inscribing difficulty. On fail the spell scroll is destroyed.
 
 #### Runesmith
 *Requires proficiency with Scribing Tools, 1 Dexterity*
@@ -4261,6 +4275,10 @@ Your experience with spell scrolls enables you to create spell scrolls for spell
 
 When a creature attacks you, you may make a reaction attack against them. This attack costs 2 AP, and you may only use this on the same creature once per round.
 
+#### Mana Recovery
+*Requires 3 proficiency in Arcane, 7th Level*
+
+When casting _Barrier_, _Counter Spell_, or blocking spell damage with _Elemental Shell_ you regain 1 mana, or 2 mana if the spell is 6th level and above, regardless of the rolls outcome.
 ___
 ### Advanced
 
@@ -4330,10 +4348,10 @@ Each character can only take 1 legendary feat, regardless of requirements.
 
 When rolling wounds from an attack or maneuver that uses your strength you may instead treat all wound dice as wounds. You can do this up to your strength score, after which you must long rest before using again.
 
-#### Fleetfoot
+#### Turnabout
 *Requires 5 Dexterity, 20th Level*
 
-When taking a move or sprint action you may spend 1 additional AP to become immune to opportunity attacks.
+When the target of an attack, if the attack misses you may make an opportunity attack against the target.
 
 #### Juggernaut
 *Requires 5 Stamina, 20th Level*
@@ -4489,7 +4507,7 @@ Roll 3 terrible dice, adding the successes. For each critical, move up one level
 | | -9 | Deadly Infection | Your max wounds are reduced by 1. At the end of each Long rest your max wounds are reduced again. |
 | | -8 | Broken Arm | You can only hold a One-Handed weapon or shield, not both. |
 | | -7 | Punctured Chest | All wound dice count as a wound, regardless of result. |
-| | -6 | Magic Tearing | Add bad dice to your spellcasting rolls equal to the spell slot's level. Spells Misfire if you fail your roll, regardless of ability. |
+| | -6 | Magic Tearing | Add bad dice to your spellcasting rolls equal to the spells level. Spells Misfire if you fail your roll, regardless of ability. |
 | | -5 | Torn Muscle | You are permanently Weakened. |
 | | -4 | Collapsed Lung | Your stamina is reduced by 1, all conditions that last until the end of your turn last an extra turn. |
 | | -3 | Broken Leg | You cannot sprint, and your move speed is reduced by 2. |
@@ -4652,31 +4670,31 @@ on hit inflicts Poison 3 for 10 minutes.
 
 ___
 #### Enchanters Tools
-  During a long rest you may attempt to enchant a single piece of mundane gear. Enchanted gear lasts for 3 days and count as magical equipment for the duration. After the Ehcantment ends the gear returns to being mundane. To enchant a piece of gear you must have a spell slot available and enough enchanting supplies for the enchantment. Then you must pass the enchanting roll, with failure consuming the spell slot and supplies but not giving the enchantment. Most cities and towns will sell enchanting supplies.
+  During a long rest you may attempt to enchant a single piece of mundane gear. Enchanted gear lasts for 3 days and count as magical equipment for the duration. After the Ehcantment ends the gear returns to being mundane. To enchant a piece of gear you must have mana available and enough enchanting supplies for the enchantment. Then you must pass the enchanting roll, with failure consuming the mana and supplies but not giving the enchantment. Most cities and towns will sell enchanting supplies.
   
-  The enchanting roll uses your skill with your enchanters tools. You may spend additional spell slots of equal level or higher to add proficient die for each spell slot spent. Ammunition loses it's enchantment on hit, whether the effect is triggered or not.
+  The enchanting roll uses your skill with your enchanters tools. You may spend additional mana, adding a proficient die for every 3 mana added. Ammunition loses it's enchantment on hit, whether the effect is triggered or not.
 
   A creature can only use 1 piece of enchanted equipment at a time.
   
   ##### Enchantments
-| | Name | Spell Slot | Supplies | Roll | Effect |
+| | Name | Mana | Supplies | Roll | Effect |
 |:----:|:-----:|:-----:|:-----:|:-----:|:-------------|
 | _Weapon_ | | | | | | 
-| | Skillful | 1st | 1 |2B | You gain 1 proficiency with this weapon type. |
-| | Brutality | 2nd | 3 |2B/1T | When you critical with this weapon, add an extra wound die to the damage. |
-| | Hexblade | 2nd | 3 |2B/1T | When you critical with this weapon the target gains Hex 1 for 1 minute. |
-| | Quickened | 3rd | 4 |2B/2T | The first attack made with this weapon each turn costs 1 less AP. |
+| | Skillful | 1 | 1 |2B | You gain 1 proficiency with this weapon type. |
+| | Brutality | 2 | 3 |2B/1T | When you critical with this weapon, add an extra wound die to the damage. |
+| | Hexblade | 2 | 3 |2B/1T | When you critical with this weapon the target gains Hex 1 for 1 minute. |
+| | Quickened | 3 | 4 |2B/2T | The first attack made with this weapon each turn costs 1 less AP. |
 | Armor | | | | | | 
-| | Durable | 2nd | 4 |2B/2T | If a spell or effect targetting this armor would damage it, roll a wound die. On a blank the armor takes no damge. |
-| | Lightened | 3rd | 4 |2B/2T | Heavy armor is treated as medium armor and medium armor is treated as light armor when calculating armor penalities and initiative |
+| | Durable | 2 | 4 |2B/2T | If a spell or effect targetting this armor would damage it, roll a wound die. On a blank the armor takes no damge. |
+| | Lightened | 3 | 4 |2B/2T | Heavy armor is treated as medium armor and medium armor is treated as light armor when calculating armor penalities and initiative |
 | _Shield_ | | | | | | 
-| | Lesser Block | 2nd | 2 |2B/1T | You may reroll 1 defense die when making defense rolls. |
-| | Greater Block | 4th | 5 |2B/3T | You may reroll 2 defense die when making defense rolls. |
+| | Lesser Block | 2 | 2 |2B/1T | You may reroll 1 defense die when making defense rolls. |
+| | Greater Block | 4 | 5 |2B/3T | You may reroll 2 defense die when making defense rolls. |
 | _Ammunition_ | | | | | | 
-| | Staggering | 1st | 1 |2B | On critical the target is staggered until the start of your next turn. Makes 3 ammunition |
-| | Slowing | 1st | 1 |2B | On critical the target gains Slow 1 until the start of your next turn. Makes 3 ammunition |
-| | Homing | 2nd | 2 |2B/1T | Creates 3 +1 magical ammunition. |
-| | Slaying | 3rd | 2 |2B/3T | Choose a creature type. This arrow deals an extra 3 wounds against creatures of this type. |
+| | Staggering | 1 | 1 |2B | On critical the target is staggered until the start of your next turn. Makes 3 ammunition |
+| | Slowing | 1 | 1 |2B | On critical the target gains Slow 1 until the start of your next turn. Makes 3 ammunition |
+| | Homing | 2 | 2 |2B/1T | Creates 3 +1 magical ammunition. |
+| | Slaying | 3 | 2 |2B/3T | Choose a creature type. This arrow deals an extra 3 wounds against creatures of this type. |
 
 
   
@@ -4684,35 +4702,35 @@ ___
 
 ___
 #### Scribing Tools
-A set of tools for writing spell scrolls and inscribing runes. During a long rest you may attempt to inscribe a single rune or spell scroll. Spell scrolls are written in a way such that anyone is able to learn it and add it to their codex. Runes are consumables that give a variety of one time effects, from enhancing one of your spells to creating a magical trap. Creating scrolls and wards requires spell slots and uses a mix of gemstones and enchanting supplies which can be found in most cities.
+A set of tools for writing spell scrolls and inscribing runes. During a long rest you may attempt to inscribe a single rune or spell scroll. Spell scrolls are written in a way such that anyone is able to learn it and add it to their codex. Runes are consumables that give a variety of one time effects, from enhancing one of your spells to creating a magical trap. Creating scrolls and wards requires mana and uses a mix of gemstones and enchanting supplies which can be found in most cities.
 
 #### Inscribing Spell Scrolls
-You can create a spell scroll for any spell in your codex that you are able to cast. Creating a spell scroll of 3rd level or lower can be done during a long rest, with spells of 4th level and higher taking 1 day of work for each level above 3rd. You must have a spell slot of the same level or higher available which is consumed in creating the scroll.
+You can create a spell scroll for any spell in your codex that you are able to cast. Creating a spell scroll of 3rd level or lower can be done during a long rest, with spells of 4th level and higher taking 1 day of work for each level above 3rd. You must have enough mana available which is consumed in creating the scroll.
 
 When copying spells from a Codex you can instead use your scribing tools to create a spell scroll. Doing so costs a single enchanting supply regardless of spell level, but ignores all other costs for creating spell scrolls. For each spell you want to remove from the Codex and turn into a scroll make a inscription roll against that spell levels difficulty. On success you create a spell scroll for that spell, with failure destroying the codex.
 
 ##### Spell Scrolls
-| Level | Spell Slot | Gemstones | Supplies | Challenge Dice |
+| Level | Mana | Gemstones | Supplies | Challenge Dice |
 |:-----:|:-----:|:-----:|:-----:|:-------------|
-| Cantrip | 1st | 10gp gemstone | 0 | 1B |
-| 1st | 1st | 10gp gemstone | 1 | 1T |
-| 2nd | 2nd | 25gp gemstone | 1 | 2T |
-| 3rd | 3rd | 25gp gemstone | 2 | 3T |
-| 4th | 4th | 50gp gemstone | 2 | 4T |
-| 5th | 5th | 50gp gemstone | 3 | 5T |
-| 6th | 6th | 100gp gemstone | 4 | 6T |
-| 7th | 7th | 250gp gemstone | 5 | 7T |
-| 8th | 8th | 500gp gemstone | 7 | 8T |
-| 9th | 9th | 1000gp gemstone | 10 | 9T |
+| Cantrip | 1 | 10gp gemstone | 0 | 1B |
+| 1st | 1 | 10gp gemstone | 1 | 1T |
+| 2nd | 2 | 25gp gemstone | 1 | 2T |
+| 3rd | 3 | 25gp gemstone | 2 | 3T |
+| 4th | 4 | 50gp gemstone | 2 | 4T |
+| 5th | 6 | 50gp gemstone | 3 | 5T |
+| 6th | 7 | 100gp gemstone | 4 | 6T |
+| 7th | 8 | 250gp gemstone | 5 | 7T |
+| 8th | 9 | 500gp gemstone | 7 | 8T |
+| 9th | 12 | 1000gp gemstone | 10 | 9T |
 
 #### Inscribing Runes
-You can inscribe a rune during a long rest or with 2 hours of downtime. To inscribe you need to have the required supplies and a spell slot of the same level or higher which is consumed in creating the rune. Runes are consumed on use, with some requiring a specific trigger to activate. Once triggered the rune is consumed regardless of the result. Unless otherwise stated, runes that agument spells require no AP to use while placing a rune takes 2 AP.
+You can inscribe a rune during a long rest or with 2 hours of downtime. To inscribe you need to have the required supplies and mana which are consumed in creating the rune. Runes are consumed on use, with some requiring a specific trigger to activate. Once triggered the rune is consumed regardless of the result. Unless otherwise stated, runes that agument spells require no AP to use while placing a rune takes 2 AP.
 
 ##### Runes
-| Rune | Spell Slot | Gemstones | Supplies | Challenge Dice | Effect |
+| Rune | Mana | Gemstones | Supplies | Challenge Dice | Effect |
 |:-----:|:-----:|:-----:|:-----:|:-----:|:-------------|
-| Longcaster | 1st | 1 10gp gemstone | 0 | 1B | Doubles the range of a spell that does not have a range of self or touch. |
-| Potency | 1st | - | 1 | 2B | The first success in your spellcasting roll counts as a crit in addition to its dice value. |
-| Fire Ward | 2nd | - | 1 | 1B/1T | Once placed, the next creature to enter its tile makes a Dexterity save vs 2 Superior dice, taking 1 wound and 1 wound die in fire damage on fail. |
-| Arc Ward | 2nd | - | 1 | 1B/1T | Once placed, the next creature to enter its tile makes a Stamina save vs 2 Superior dice, becoming Paralyzed for 1 minute on fail. |
-| Expanding | 3rd | 1 25gp gemstone | 1 | 2T | Increases the area effected by a spell by 1. |
+| Longcaster | 1 | 1 10gp gemstone | 0 | 1B | Doubles the range of a spell that does not have a range of self or touch. |
+| Potency | 1 | - | 1 | 2B | The first success in your spellcasting roll counts as a crit in addition to its dice value. |
+| Fire Ward | 2 | - | 1 | 1B/1T | Once placed, the next creature to enter its tile makes a Dexterity save vs 2 Superior dice, taking 1 wound and 1 wound die in fire damage on fail. |
+| Arc Ward | 2 | - | 1 | 1B/1T | Once placed, the next creature to enter its tile makes a Stamina save vs 2 Superior dice, becoming Paralyzed for 1 minute on fail. |
+| Expanding | 3 | 1 25gp gemstone | 1 | 2T | Increases the area effected by a spell by 1. |

--- a/rulesdoc.md
+++ b/rulesdoc.md
@@ -396,6 +396,7 @@ Finally, choose 2 of the following bonuses.
 - Learn 1 Feat
 - Learn a maneuver and gain 2 proficiency with a weapon type
 - Increase your max wounds by 1
+- Increase your spell power by 5 and gain 3 mana
 
 ##### Variant Rule - Rolling for Attributes
 Instead of using the rules above for attributes, your group may decide to roll your scores. For each attribute roll 1 Superior, 3 Normal, and 1 Terrible die, adding up the total successes. The minimum score for an attribute is -2, with any rolls below that counting as -2 for the roll.
@@ -418,10 +419,10 @@ Currency in Farhome is divided into 3 types: the copper trite, silver cross, and
 
 ### Leveling Up
 
-When you earn 1000 experience your character levels up. Each level you gain 2 proficiency points and choose one of the following bonuses:
+When you earn 1000 experience your character levels up. Each level you gain 1 proficiency point and choose one of the following bonuses:
 
-- Gain 3 spell power. Gain mana based on your spell power below.*
-- Gain 4 proficiency points
+- Gain 3 spell power. Gain mana based on your spell power.*
+- Gain 3 proficiency points
 - Gain a Feat
 - Learn a Maneuver
 - Increase your max wounds by 1

--- a/rulesdoc.md
+++ b/rulesdoc.md
@@ -430,7 +430,7 @@ When you earn 1000 experience your character levels up. Each level you gain 1 pr
 **Mana**
 When gaining mana, you apply the spell power gained from leveling up before adding mana from the chart below.
 
-| Player Level | Spell Level |
+| Spell Power | Spell Level |
 |:----:|:----:|
 | 1-8  | 3 |
 | 9-18  | 4 |
@@ -781,6 +781,16 @@ ___
 ##### Devil Blood
 
 You take no penalities when in dim light, and only add 1 bad die in total darkness. While not in sunlight you can reroll 1 die when making Charisma skill challenges.
+
+___
+#### Sylvan
+- **Starting Wounds:** 3
+- **Move/Sprint:** 4/3
+- **Attribute Bonuses:** +1 Intelligence, +1 Charisma, -1 Strength
+
+##### Forestfolk
+
+During a short or long rest you restore 1 extra wound and mana. This feature has no effect if you've taken fire damage since your last rest.
 
 ### Dwarf
 
@@ -1137,9 +1147,9 @@ ___
 - **Range:** Self
 - **Duration:** instant
 
-As a reaction you quickly pull up magical defenses, protecting you and all creatures adjacent to yourself. You and all effected creatures can add 2 superior dice against the incoming spell. If the spell does not require a save, roll the 2 superior dice vs the casters spellcasting roll. On a success the spell has no effect.
+As a reaction you quickly pull up magical defenses, protecting you and all creatures adjacent to yourself. Make a spellcasting roll, you and all effected creatures add 1 superior die, adding an extra superior die for every crit, against the incoming spell. If the spell does not require a save, roll the superior dice against the casters spellcasting roll. On a success the spell has no effect.
 
-Increase the range of protection by 1 for every level above the first.
+Increase the range of protection by 1 and add a proficiency die for every level above the first.
 
 ___
 #### Combust
@@ -1255,9 +1265,9 @@ ___
 You attempt to animate a simple object made of plant, wood, stone, or metal no more than 1 tile in size. If the object is part of a larger construction (a stone wall, a dirt mound, etc) you add 1 terrible die to your roll as you try to force it free.
 
 
-Make a spellcasting roll adding a terrible die if the target is metal, on success you create a golem out of the object. The golem has 3 wounds and acts on your turn. It can take a move action to move 4 tiles and can make a single attack. The golem's attack uses 3 dice, improing one die for every success and adding a die for every crit. After the duration or if the caster is incapacitated the golem reverts to inanimate material.
+Make a spellcasting roll adding 2 terrible dice or 4 terrible dice if the meterial is metal. On success you create a golem out of the object. The golem has 3 wounds and acts on your turn. It can take a move action to move 4 tiles and can make a single attack. The golem's attack uses 5 normal dice, improing one die for every success and adding a die for every crit. The creature deals 1 wound on hit, adding a wound die for every size increase. After the duration or if the caster is incapacitated the golem reverts to inanimate material. Golems made of metal have _Resistance 1_ to physical damage.
 
-Add a proficient die for every level above 3rd. At 5th level you may target a 2x2 area, and at 7th a 3x3 area.
+Add a proficient die for every level above 3rd. At 5th level you may target a 2x2 area creating a golem with 5 wounds, and at 7th a 3x3 area creating a golem with 8 wounds and two attacks per turn.
 
 ___
 #### Chain Lightning

--- a/rulesdoc.md
+++ b/rulesdoc.md
@@ -4066,7 +4066,7 @@ When you crit with an attack, add an extra wound die.
 #### Second Wind
 *Requires 1 Stamina*
 
-While in combat you may spend 3 AP on your turn to use a Healing Surge. This can be used once per rest.
+While in combat you may spend 3 AP on your turn to roll a free Healing Surge. This can be used once per rest.
 
 #### Battering Ram
 *Requires 3 Stamina*
@@ -4184,7 +4184,7 @@ You add 1 superior die when making Enchantment rolls. Enchantments you make last
 #### Mana Font
 *Requires 2 Intelligence*
 
-While in combat you may spend 3 AP to restore mana equal to half your level, rounded up. After use, cannot be used again until taking a rest.
+While in combat you may spend 3 AP to restore mana equal to half your level, rounded up. After use, cannot be used again until taking a long rest.
 
 #### Arcane Forge
 *Requires proficiency with Enchanters Tools*


### PR DESCRIPTION
So, there's some problems with how you gain spell slots today. Spell slots are also a little abstract and the rules for gaining/upgrading them are confusing as all hell.

This is one solution I came up with to fix this. You now have **Spell Power** and **Mana**. **Spell Power** basically only exists to determine how much mana you get when you level up. **Mana** is basically if you took all your spell slots and put it into a shared pool. Spells cost more or less 1 mana per spell level, increasing in cost at higher levels. I like this for a number of reasons:
- It makes more sense from an immersion perspective. Casting takes some kind of power from the caster, but it's weird that it's segmented out into well defined boxes. Pretty sure D&D did this entirely for balancing issues, but I haven't played a campaign with 9th level casters so I'm going to assume its balanced here.
- It massively simplifies the rules for spellcasting. Now all you need to do is look at your prepared spells and see if you have enough mana. When leveling up the amount of mana you gain is set and you don't have to faff about increasing/adding different slots.
- It adds some cool power progression to casters. Higher tier spells aren't as bonkers in this as D&D, at least I think? But the more mana you have the less costly casting 1st and 2nd level spells become, with you being able to cast them 30-40 times before running out of mana. a 25th+ level caster should definitely be able to sling lvl 1 spells almost effortlessly.
- It gives casters huge utility to be able to choose their spell slots on demand like this. Because of this you'll have less mana than if you summed up all your spell slots at this level. It recovers slightly faster too, but from my numbers an average caster will get ~3 casts at their highest level from their mana pool, growing to ~5 at end game.


Also changed currency values for shits and giggles.